### PR TITLE
Port-forward tunnel liveness probe + dashboard heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ gossm
 CLAUDE.md
 AGENT.md
 docs/superpowers
+.playwright-mcp/
+.claude/
+.aws/
+build/
 
 # Antora build output
 src/docs/build/

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -152,6 +152,11 @@ func (m *SessionManager) StartSession(opts SessionOpts) (string, error) {
 	// Monitor the subprocess in the background.
 	go m.monitor(s)
 
+	// Probe the tunnel for liveness if this is a port-forward session.
+	if s.Type == TypePortForward {
+		go m.monitorProbe(s)
+	}
+
 	return id, nil
 }
 
@@ -283,6 +288,10 @@ func (m *SessionManager) RegisterExternal(opts SessionOpts, pid int) string {
 		go m.monitorExternalPID(s)
 	}
 
+	if s.Type == TypePortForward {
+		go m.monitorProbe(s)
+	}
+
 	return id
 }
 
@@ -348,5 +357,79 @@ func (m *SessionManager) emit(e SessionEvent) {
 	select {
 	case m.OnChange <- e:
 	default:
+	}
+}
+
+// monitorProbe periodically runs the prober for a port-forward session.
+// On a Running → probe-fails edge it transitions to StateStalled; on a
+// Stalled → probe-succeeds edge it transitions back to Running. The
+// goroutine exits when the session leaves an active state, when stopCh
+// is closed, or when the prober is nil.
+func (m *SessionManager) monitorProbe(s *Session) {
+	m.mu.RLock()
+	interval := m.probeInterval
+	timeout := m.probeTimeout
+	prober := m.prober
+	m.mu.RUnlock()
+
+	if prober == nil || interval <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			ok := prober(ctx, s)
+			cancel()
+
+			m.mu.Lock()
+			cur, exists := m.sessions[s.ID]
+			if !exists {
+				m.mu.Unlock()
+				return
+			}
+
+			// Exit if the session has left an active state.
+			if cur.State == StateStopping || cur.State == StateStopped || cur.State == StateErrored {
+				m.mu.Unlock()
+				return
+			}
+
+			cur.LastProbeAt = time.Now()
+			cur.LastProbeOK = ok
+
+			stateChanged := false
+			switch {
+			case !ok && cur.State == StateRunning:
+				cur.State = StateStalled
+				stateChanged = true
+			case ok && cur.State == StateStalled:
+				cur.State = StateRunning
+				stateChanged = true
+			}
+			m.mu.Unlock()
+
+			if stateChanged {
+				m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+			}
+		}
+	}
+}
+
+// markRunningForTest forces a session into StateRunning. It exists so
+// tests can drive sessions started with sleepBuilder() (which never
+// reach Running on their own because monitor() only updates state on
+// process exit) through state transitions exercised by monitorProbe.
+func (m *SessionManager) markRunningForTest(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.sessions[id]; ok {
+		s.State = StateRunning
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -377,6 +377,12 @@ func (m *SessionManager) monitorProbe(s *Session) {
 		return
 	}
 
+	// Run an initial probe immediately so the dashboard does not show
+	// "pending" for a full interval after the session starts.
+	if !m.runProbe(s, prober, timeout) {
+		return
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -385,41 +391,50 @@ func (m *SessionManager) monitorProbe(s *Session) {
 		case <-m.stopCh:
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			ok := prober(ctx, s)
-			cancel()
-
-			m.mu.Lock()
-			cur, exists := m.sessions[s.ID]
-			if !exists {
-				m.mu.Unlock()
+			if !m.runProbe(s, prober, timeout) {
 				return
-			}
-
-			// Exit if the session has left an active state.
-			if cur.State == StateStopping || cur.State == StateStopped || cur.State == StateErrored {
-				m.mu.Unlock()
-				return
-			}
-
-			cur.LastProbeAt = time.Now()
-			cur.LastProbeOK = ok
-
-			stateChanged := false
-			switch {
-			case !ok && cur.State == StateRunning:
-				cur.State = StateStalled
-				stateChanged = true
-			case ok && cur.State == StateStalled:
-				cur.State = StateRunning
-				stateChanged = true
-			}
-			m.mu.Unlock()
-
-			if stateChanged {
-				m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
 			}
 		}
 	}
+}
+
+// runProbe executes a single probe against s and applies the result to
+// the session record. It returns false to signal that monitorProbe
+// should exit (because the session has been removed from the registry
+// or has reached a terminal state).
+func (m *SessionManager) runProbe(s *Session, prober Prober, timeout time.Duration) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ok := prober(ctx, s)
+	cancel()
+
+	m.mu.Lock()
+	cur, exists := m.sessions[s.ID]
+	if !exists {
+		m.mu.Unlock()
+		return false
+	}
+	if cur.State == StateStopping || cur.State == StateStopped || cur.State == StateErrored {
+		m.mu.Unlock()
+		return false
+	}
+
+	cur.LastProbeAt = time.Now()
+	cur.LastProbeOK = ok
+
+	stateChanged := false
+	switch {
+	case !ok && cur.State == StateRunning:
+		cur.State = StateStalled
+		stateChanged = true
+	case ok && cur.State == StateStalled:
+		cur.State = StateRunning
+		stateChanged = true
+	}
+	m.mu.Unlock()
+
+	if stateChanged {
+		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+	}
+	return true
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -142,6 +142,7 @@ func (m *SessionManager) StartSession(opts SessionOpts) (string, error) {
 	}
 
 	s.PID = cmd.Process.Pid
+	s.State = StateRunning
 
 	m.mu.Lock()
 	m.sessions[id] = s

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -422,14 +422,3 @@ func (m *SessionManager) monitorProbe(s *Session) {
 	}
 }
 
-// markRunningForTest forces a session into StateRunning. It exists so
-// tests can drive sessions started with sleepBuilder() (which never
-// reach Running on their own because monitor() only updates state on
-// process exit) through state transitions exercised by monitorProbe.
-func (m *SessionManager) markRunningForTest(id string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if s, ok := m.sessions[id]; ok {
-		s.State = StateRunning
-	}
-}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -45,14 +45,17 @@ func defaultTCPProber(ctx context.Context, s *Session) bool {
 
 // SessionManager is a goroutine-safe registry of active SSM sessions.
 type SessionManager struct {
-	mu           sync.RWMutex
-	sessions     map[string]*Session
-	OnChange     chan SessionEvent
-	buildCommand CommandBuilder
-	checkProcess ProcessChecker
-	sparkData    []int // ring buffer of active session counts, last 60 entries
-	sparkIndex   int
-	stopCh       chan struct{}
+	mu            sync.RWMutex
+	sessions      map[string]*Session
+	OnChange      chan SessionEvent
+	buildCommand  CommandBuilder
+	checkProcess  ProcessChecker
+	prober        Prober
+	probeInterval time.Duration
+	probeTimeout  time.Duration
+	sparkData     []int // ring buffer of active session counts, last 60 entries
+	sparkIndex    int
+	stopCh        chan struct{}
 }
 
 // New creates a SessionManager.  If builder is nil the default AWS CLI
@@ -63,12 +66,31 @@ func New(builder CommandBuilder, checker ProcessChecker) *SessionManager {
 		builder = defaultCommandBuilder
 	}
 	return &SessionManager{
-		sessions:     make(map[string]*Session),
-		OnChange:     make(chan SessionEvent, 64),
-		buildCommand: builder,
-		checkProcess: checker,
-		sparkData:    make([]int, 60),
-		stopCh:       make(chan struct{}),
+		sessions:      make(map[string]*Session),
+		OnChange:      make(chan SessionEvent, 64),
+		buildCommand:  builder,
+		checkProcess:  checker,
+		prober:        defaultTCPProber,
+		probeInterval: 30 * time.Second,
+		probeTimeout:  2 * time.Second,
+		sparkData:     make([]int, 60),
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// SetProbe overrides the prober, probe interval, and per-probe timeout.
+// Pass interval=0 or timeout=0 to keep the existing values for those
+// individual knobs. Pass prober=nil to disable probing entirely.
+// Intended for tests and for higher layers wanting custom liveness checks.
+func (m *SessionManager) SetProbe(p Prober, interval, timeout time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prober = p
+	if interval > 0 {
+		m.probeInterval = interval
+	}
+	if timeout > 0 {
+		m.probeTimeout = timeout
 	}
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"net"
 	"os/exec"
 	"sync"
 	"time"
@@ -17,6 +18,30 @@ type CommandBuilder func(ctx context.Context, opts SessionOpts) *exec.Cmd
 // ProcessChecker tests whether a process with the given PID is still alive.
 // Injecting this allows the manager to monitor externally registered sessions.
 type ProcessChecker func(pid int) bool
+
+// Prober tests whether a port-forward tunnel is still functional.
+// It should return true when the tunnel passes its liveness check.
+// The context carries the probe deadline.
+type Prober func(ctx context.Context, s *Session) bool
+
+// defaultTCPProber dials 127.0.0.1:LocalPort with the deadline carried
+// by ctx. A successful connect indicates the local plugin listener is
+// up; over time, dial failures correlate strongly with a torn-down
+// tunnel because the plugin closes its listener when the SSM control
+// channel is lost.
+func defaultTCPProber(ctx context.Context, s *Session) bool {
+	if s.Type != TypePortForward || s.LocalPort == 0 {
+		return false
+	}
+	d := net.Dialer{}
+	addr := fmt.Sprintf("127.0.0.1:%d", s.LocalPort)
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
 
 // SessionManager is a goroutine-safe registry of active SSM sessions.
 type SessionManager struct {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"net"
 	"os/exec"
 	"strings"
 	"sync"
@@ -429,5 +430,43 @@ func TestStateStalledDistinct(t *testing.T) {
 	}
 	if StateStalled == StateErrored {
 		t.Fatal("StateStalled must not collide with StateErrored")
+	}
+}
+
+func TestDefaultTCPProberSucceedsOnLiveListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	s := &Session{
+		Type:      TypePortForward,
+		LocalPort: port,
+	}
+
+	if !defaultTCPProber(context.Background(), s) {
+		t.Errorf("defaultTCPProber returned false on a live listener at 127.0.0.1:%d", port)
+	}
+}
+
+func TestDefaultTCPProberFailsOnDeadPort(t *testing.T) {
+	// Bind a port to discover one that's free, then close the listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	s := &Session{
+		Type:      TypePortForward,
+		LocalPort: port,
+	}
+
+	if defaultTCPProber(context.Background(), s) {
+		t.Errorf("defaultTCPProber returned true for a closed port %d", port)
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -398,3 +398,36 @@ func TestNoMonitoringWhenCheckerNil(t *testing.T) {
 		t.Errorf("state = %d, want StateRunning(%d) — nil checker should not monitor", s.State, StateRunning)
 	}
 }
+
+func TestSessionDefaultProbeFields(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	id, err := sm.StartSession(testOpts("probe-default"))
+	if err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+
+	s, ok := sm.GetSession(id)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if !s.LastProbeAt.IsZero() {
+		t.Errorf("LastProbeAt = %v, want zero value", s.LastProbeAt)
+	}
+	if s.LastProbeOK {
+		t.Errorf("LastProbeOK = true, want false on a freshly started session")
+	}
+}
+
+func TestStateStalledDistinct(t *testing.T) {
+	if StateStalled == StateRunning {
+		t.Fatal("StateStalled must not collide with StateRunning")
+	}
+	if StateStalled == StateStopped {
+		t.Fatal("StateStalled must not collide with StateStopped")
+	}
+	if StateStalled == StateErrored {
+		t.Fatal("StateStalled must not collide with StateErrored")
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -542,7 +542,7 @@ func TestProbeUpdatesLastProbeFields(t *testing.T) {
 	// Mark Running so monitorProbe doesn't skip it.
 	sm.markRunningForTest(id)
 
-	// Wait long enough for at least 3 probes.
+	// Wait long enough for at least 2 probes.
 	time.Sleep(150 * time.Millisecond)
 
 	s, ok := sm.GetSession(id)
@@ -682,4 +682,16 @@ func waitForState(sm *SessionManager, id string, want SessionState, timeout time
 		return fmt.Errorf("state = %d, want %d (after %v)", s.State, want, timeout)
 	}
 	return fmt.Errorf("session %s not found", id)
+}
+
+// markRunningForTest forces a session into StateRunning. It exists so
+// tests can drive sessions started with sleepBuilder() (which never
+// reach Running on their own because monitor() only updates state on
+// process exit) through state transitions exercised by monitorProbe.
+func (m *SessionManager) markRunningForTest(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.sessions[id]; ok {
+		s.State = StateRunning
+	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os/exec"
 	"strings"
@@ -509,4 +510,176 @@ func TestNewInstallsDefaults(t *testing.T) {
 	if sm.probeTimeout == 0 {
 		t.Fatal("New should install a non-zero probeTimeout")
 	}
+}
+
+// portForwardOpts builds a SessionOpts for a port-forward to a given local port.
+func portForwardOpts(name string, localPort int) SessionOpts {
+	return SessionOpts{
+		InstanceID:   "i-" + name,
+		InstanceName: name,
+		Profile:      "default",
+		Type:         TypePortForward,
+		LocalPort:    localPort,
+		RemotePort:   localPort,
+		RemoteHost:   "remote.local",
+	}
+}
+
+func TestProbeUpdatesLastProbeFields(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var probes atomic.Int32
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		probes.Add(1)
+		return true
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	id, err := sm.StartSession(portForwardOpts("probe-up", 12345))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	// Mark Running so monitorProbe doesn't skip it.
+	sm.markRunningForTest(id)
+
+	// Wait long enough for at least 3 probes.
+	time.Sleep(150 * time.Millisecond)
+
+	s, ok := sm.GetSession(id)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if probes.Load() < 2 {
+		t.Errorf("probe count = %d, want >= 2", probes.Load())
+	}
+	if s.LastProbeAt.IsZero() {
+		t.Errorf("LastProbeAt should have been updated")
+	}
+	if !s.LastProbeOK {
+		t.Errorf("LastProbeOK should be true after a successful probe")
+	}
+}
+
+func TestProbeFailureTransitionsToStalled(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var fail atomic.Bool
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		return !fail.Load()
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	id, err := sm.StartSession(portForwardOpts("probe-stall", 12346))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	sm.markRunningForTest(id)
+
+	// Drain the OnChange channel so we can wait for a fresh "updated" event.
+	drainEvents(sm.OnChange)
+
+	// Flip the prober to fail.
+	fail.Store(true)
+
+	if err := waitForState(sm, id, StateStalled, time.Second); err != nil {
+		t.Fatalf("waiting for StateStalled: %v", err)
+	}
+}
+
+func TestProbeRecoveryTransitionsBackToRunning(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var fail atomic.Bool
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		return !fail.Load()
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	id, err := sm.StartSession(portForwardOpts("probe-recover", 12347))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	sm.markRunningForTest(id)
+
+	fail.Store(true)
+	if err := waitForState(sm, id, StateStalled, time.Second); err != nil {
+		t.Fatalf("waiting for StateStalled: %v", err)
+	}
+
+	fail.Store(false)
+	if err := waitForState(sm, id, StateRunning, time.Second); err != nil {
+		t.Fatalf("waiting for StateRunning recovery: %v", err)
+	}
+}
+
+func TestProbeNotStartedForShellSessions(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var probes atomic.Int32
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		probes.Add(1)
+		return true
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	id, err := sm.StartSession(testOpts("shell-no-probe"))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	sm.markRunningForTest(id)
+
+	time.Sleep(150 * time.Millisecond)
+
+	if probes.Load() != 0 {
+		t.Errorf("shell session probed %d times; expected 0", probes.Load())
+	}
+}
+
+func TestProbeStopsOnClose(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		return true
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	if _, err := sm.StartSession(portForwardOpts("close", 12348)); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		sm.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return — probe goroutine likely leaked")
+	}
+}
+
+// --- test helpers used above ---
+
+func drainEvents(ch <-chan SessionEvent) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+func waitForState(sm *SessionManager, id string, want SessionState, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s, ok := sm.GetSession(id); ok && s.State == want {
+			return nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if s, ok := sm.GetSession(id); ok {
+		return fmt.Errorf("state = %d, want %d (after %v)", s.State, want, timeout)
+	}
+	return fmt.Errorf("session %s not found", id)
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -695,3 +695,22 @@ func (m *SessionManager) markRunningForTest(id string) {
 		s.State = StateRunning
 	}
 }
+
+func TestStartSessionSetsStateRunning(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	id, err := sm.StartSession(testOpts("running"))
+	if err != nil {
+		t.Fatalf("StartSession failed: %v", err)
+	}
+
+	s, ok := sm.GetSession(id)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if s.State != StateRunning {
+		t.Errorf("State = %d, want StateRunning(%d) — session should be Running once subprocess is spawned, not Starting",
+			s.State, StateRunning)
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -696,6 +696,48 @@ func (m *SessionManager) markRunningForTest(id string) {
 	}
 }
 
+func TestProbeFiresImmediately(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var probes atomic.Int32
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		probes.Add(1)
+		return true
+	}, 500*time.Millisecond, 100*time.Millisecond)
+
+	if _, err := sm.StartSession(portForwardOpts("immediate", 12350)); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Wait well under the probe interval. With an immediate probe, at
+	// least one probe should have fired by now.
+	time.Sleep(80 * time.Millisecond)
+
+	if probes.Load() == 0 {
+		t.Errorf("expected ≥1 probe within 80ms (interval is 500ms) — first probe should fire immediately, not wait a full interval")
+	}
+}
+
+func TestRegisterExternalPortForwardIsProbed(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var probes atomic.Int32
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		probes.Add(1)
+		return true
+	}, 30*time.Millisecond, 50*time.Millisecond)
+
+	sm.RegisterExternal(portForwardOpts("ext-pf", 12349), 99999)
+
+	time.Sleep(120 * time.Millisecond)
+
+	if probes.Load() == 0 {
+		t.Errorf("externally registered port-forward session was not probed")
+	}
+}
+
 func TestStartSessionSetsStateRunning(t *testing.T) {
 	sm := New(sleepBuilder(), nil)
 	defer sm.Close()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -470,3 +470,43 @@ func TestDefaultTCPProberFailsOnDeadPort(t *testing.T) {
 		t.Errorf("defaultTCPProber returned true for a closed port %d", port)
 	}
 }
+
+func TestSetProbeOverridesDefault(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	called := false
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		called = true
+		return true
+	}, 50*time.Millisecond, 100*time.Millisecond)
+
+	if sm.probeInterval != 50*time.Millisecond {
+		t.Errorf("probeInterval = %v, want 50ms", sm.probeInterval)
+	}
+	if sm.probeTimeout != 100*time.Millisecond {
+		t.Errorf("probeTimeout = %v, want 100ms", sm.probeTimeout)
+	}
+
+	if !sm.prober(context.Background(), &Session{}) {
+		t.Errorf("installed prober did not run")
+	}
+	if !called {
+		t.Errorf("installed prober was not invoked")
+	}
+}
+
+func TestNewInstallsDefaults(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	if sm.prober == nil {
+		t.Fatal("New should install a default prober")
+	}
+	if sm.probeInterval == 0 {
+		t.Fatal("New should install a non-zero probeInterval")
+	}
+	if sm.probeTimeout == 0 {
+		t.Fatal("New should install a non-zero probeTimeout")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -21,6 +21,7 @@ const (
 	StateStarting SessionState = iota
 	StateRunning
 	StateStopping
+	StateStalled
 	StateStopped
 	StateErrored
 )
@@ -39,7 +40,9 @@ type Session struct {
 	RemoteHost   string // port forwarding only
 	StartedAt    time.Time
 	LastError    string
-	PID          int // PID of the aws ssm subprocess
+	PID          int       // PID of the aws ssm subprocess
+	LastProbeAt  time.Time // last time the tunnel probe ran (port-forward only)
+	LastProbeOK  bool      // outcome of the last probe (port-forward only)
 	cmd          *exec.Cmd
 	cancel       context.CancelFunc
 	waitDone     chan struct{} // closed when cmd.Wait() completes in monitor

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -336,6 +336,8 @@ func sessionStateClass(state session.SessionState) string {
 		return "bg-yellow-500"
 	case session.StateStopping:
 		return "bg-yellow-500"
+	case session.StateStalled:
+		return "bg-amber-500"
 	case session.StateErrored:
 		return "bg-red-500"
 	case session.StateStopped:
@@ -354,6 +356,8 @@ func sessionStateName(state session.SessionState) string {
 		return "Starting"
 	case session.StateStopping:
 		return "Stopping"
+	case session.StateStalled:
+		return "Stalled"
 	case session.StateErrored:
 		return "Errored"
 	case session.StateStopped:
@@ -384,6 +388,36 @@ func portDisplay(s session.Session) string {
 		return fmt.Sprintf("%d → %s:%d", s.LocalPort, s.RemoteHost, s.RemotePort)
 	}
 	return fmt.Sprintf("%d → %d", s.LocalPort, s.RemotePort)
+}
+
+// sessionProbeDisplay formats the probe outcome for the dashboard.
+// Shell sessions return "—" since they aren't probed. Port-forward
+// sessions return "pending" until the first probe fires, then either
+// "ok <Ns ago>" or "fail <Ns ago>".
+func sessionProbeDisplay(s session.Session) string {
+	if s.Type != session.TypePortForward {
+		return "—"
+	}
+	if s.LastProbeAt.IsZero() {
+		return "pending"
+	}
+	age := time.Since(s.LastProbeAt)
+	prefix := "ok"
+	if !s.LastProbeOK {
+		prefix = "fail"
+	}
+	return fmt.Sprintf("%s %s ago", prefix, shortDuration(age))
+}
+
+// shortDuration formats a duration as e.g. "4s", "2m", "1h".
+func shortDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
 }
 
 // uptimeSince returns a human-readable duration since the given time.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -26,6 +26,7 @@ type DashboardData struct {
 	Port         int
 	SparkSVG     template.HTML
 	Presets      []config.SessionPreset
+	LastUpdate   string
 }
 
 // handleDashboard renders the full dashboard page.
@@ -276,6 +277,7 @@ func (s *Server) buildDashboardData() DashboardData {
 		Port:         s.cfg.DashboardPort,
 		SparkSVG:     template.HTML(renderSparkSVG(s.sm.SparkData())),
 		Presets:      s.cfg.Presets,
+		LastUpdate:   time.Now().Format("15:04:05"),
 	}
 }
 

--- a/internal/web/helpers_test.go
+++ b/internal/web/helpers_test.go
@@ -186,3 +186,55 @@ func TestRenderSparkSVG_AllZeros(t *testing.T) {
 		t.Error("expected SVG output for all-zero data")
 	}
 }
+
+func TestSessionStateClassStalled(t *testing.T) {
+	got := sessionStateClass(session.StateStalled)
+	if got != "bg-amber-500" {
+		t.Errorf("sessionStateClass(StateStalled) = %q, want %q", got, "bg-amber-500")
+	}
+}
+
+func TestSessionStateNameStalled(t *testing.T) {
+	got := sessionStateName(session.StateStalled)
+	if got != "Stalled" {
+		t.Errorf("sessionStateName(StateStalled) = %q, want %q", got, "Stalled")
+	}
+}
+
+func TestSessionProbeDisplayShellShowsDash(t *testing.T) {
+	s := session.Session{Type: session.TypeShell}
+	if got := sessionProbeDisplay(s); got != "—" {
+		t.Errorf("sessionProbeDisplay(shell) = %q, want %q", got, "—")
+	}
+}
+
+func TestSessionProbeDisplayUnprobed(t *testing.T) {
+	s := session.Session{Type: session.TypePortForward}
+	if got := sessionProbeDisplay(s); got != "pending" {
+		t.Errorf("sessionProbeDisplay(unprobed) = %q, want %q", got, "pending")
+	}
+}
+
+func TestSessionProbeDisplayOK(t *testing.T) {
+	s := session.Session{
+		Type:        session.TypePortForward,
+		LastProbeAt: time.Now().Add(-12 * time.Second),
+		LastProbeOK: true,
+	}
+	got := sessionProbeDisplay(s)
+	if !strings.HasPrefix(got, "ok ") {
+		t.Errorf("sessionProbeDisplay(ok) = %q, want prefix %q", got, "ok ")
+	}
+}
+
+func TestSessionProbeDisplayFail(t *testing.T) {
+	s := session.Session{
+		Type:        session.TypePortForward,
+		LastProbeAt: time.Now().Add(-3 * time.Second),
+		LastProbeOK: false,
+	}
+	got := sessionProbeDisplay(s)
+	if !strings.HasPrefix(got, "fail ") {
+		t.Errorf("sessionProbeDisplay(fail) = %q, want prefix %q", got, "fail ")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -36,11 +36,12 @@ type Server struct {
 // and starts the SSE broker.
 func NewServer(sm *session.SessionManager, cfg *config.Config, startedAt time.Time, ec2Factory EC2ClientFactory) *Server {
 	funcMap := template.FuncMap{
-		"sessionStateClass": sessionStateClass,
-		"sessionStateName":  sessionStateName,
-		"sessionTypeName":   sessionTypeName,
-		"portDisplay":       portDisplay,
-		"uptimeSince":       uptimeSince,
+		"sessionStateClass":   sessionStateClass,
+		"sessionStateName":    sessionStateName,
+		"sessionTypeName":     sessionTypeName,
+		"portDisplay":         portDisplay,
+		"sessionProbeDisplay": sessionProbeDisplay,
+		"uptimeSince":         uptimeSince,
 	}
 
 	tmpl := template.Must(

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -556,6 +557,46 @@ func TestDashboardIncludesInstancePicker(t *testing.T) {
 	}
 	if !strings.Contains(body, "/api/instances") {
 		t.Error("dashboard does not contain /api/instances HTMX endpoint")
+	}
+}
+
+func TestSessionRowRendersProbeAndStalledStop(t *testing.T) {
+	sm := session.New(nil, nil)
+	defer sm.Close()
+
+	srv := NewServer(sm, &config.Config{}, time.Now(), nil)
+
+	// Build a port-forward session that's been probed and is in StateStalled.
+	s := session.Session{
+		ID:           "abc-123",
+		InstanceID:   "i-xyz",
+		InstanceName: "db",
+		Profile:      "prod",
+		Type:         session.TypePortForward,
+		State:        session.StateStalled,
+		LocalPort:    5432,
+		RemotePort:   5432,
+		RemoteHost:   "db.internal",
+		StartedAt:    time.Now().Add(-2 * time.Minute),
+		LastProbeAt:  time.Now().Add(-5 * time.Second),
+		LastProbeOK:  false,
+	}
+
+	var buf bytes.Buffer
+	if err := srv.tmpl.ExecuteTemplate(&buf, "session_row.html", s); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "Stalled") {
+		t.Errorf("rendered row missing 'Stalled' label: %s", out)
+	}
+	if !strings.Contains(out, "fail ") {
+		t.Errorf("rendered row missing probe 'fail ' indicator: %s", out)
+	}
+	// Stop button should be available while Stalled.
+	if !strings.Contains(out, `hx-delete="/api/sessions/abc-123"`) {
+		t.Errorf("rendered row missing Stop button while Stalled: %s", out)
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -565,6 +565,7 @@ func TestSessionRowRendersProbeAndStalledStop(t *testing.T) {
 	defer sm.Close()
 
 	srv := NewServer(sm, &config.Config{}, time.Now(), nil)
+	defer srv.Stop()
 
 	// Build a port-forward session that's been probed and is in StateStalled.
 	s := session.Session{

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -598,6 +599,35 @@ func TestSessionRowRendersProbeAndStalledStop(t *testing.T) {
 	// Stop button should be available while Stalled.
 	if !strings.Contains(out, `hx-delete="/api/sessions/abc-123"`) {
 		t.Errorf("rendered row missing Stop button while Stalled: %s", out)
+	}
+}
+
+func TestStatsRendersHeartbeat(t *testing.T) {
+	srv := testServer(t)
+
+	req := httptest.NewRequest("GET", "/api/stats", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Updated ") {
+		t.Errorf("stats response missing 'Updated ' label: %s", body)
+	}
+	// Match an HH:MM:SS pattern. Use a simple regexp.
+	matched, err := regexp.MatchString(`Updated\s+\d{2}:\d{2}:\d{2}`, body)
+	if err != nil {
+		t.Fatalf("regexp: %v", err)
+	}
+	if !matched {
+		t.Errorf("stats response does not contain a HH:MM:SS timestamp: %s", body)
+	}
+	// The pulse element should be rendered with the heartbeat-pulse class.
+	if !strings.Contains(body, "heartbeat-pulse") {
+		t.Errorf("stats response missing pulse element with class 'heartbeat-pulse': %s", body)
 	}
 }
 

--- a/internal/web/templates/layout.html
+++ b/internal/web/templates/layout.html
@@ -10,6 +10,12 @@
     <style>
         body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }
         .status-dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+        @keyframes heartbeat-pulse-anim {
+            0%   { transform: scale(1);    opacity: 1; box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7); }
+            70%  { transform: scale(1.6);  opacity: 0.6; box-shadow: 0 0 0 6px rgba(34, 197, 94, 0); }
+            100% { transform: scale(1);    opacity: 1; box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+        }
+        .heartbeat-pulse { animation: heartbeat-pulse-anim 1s ease-out 1; }
     </style>
 </head>
 <body class="bg-slate-900 text-slate-200 min-h-screen">

--- a/internal/web/templates/partials/session_row.html
+++ b/internal/web/templates/partials/session_row.html
@@ -5,6 +5,9 @@
             <span class="status-dot {{sessionStateClass .State}}"></span>
             <span class="text-xs text-slate-400">{{sessionStateName .State}}</span>
         </div>
+        {{if eq (sessionTypeName .Type) "Port Forward"}}
+        <div class="text-[10px] text-slate-500 mt-1">probe: {{sessionProbeDisplay .}}</div>
+        {{end}}
     </td>
     <td class="px-6 py-3 font-medium text-slate-200">{{.InstanceName}}</td>
     <td class="px-6 py-3 font-mono text-xs text-slate-400">{{.InstanceID}}</td>
@@ -18,7 +21,8 @@
     <td class="px-6 py-3 font-mono text-xs text-slate-400">{{portDisplay .}}</td>
     <td class="px-6 py-3 text-slate-400 text-xs">{{uptimeSince .StartedAt}}</td>
     <td class="px-6 py-3">
-        {{if or (eq (sessionStateName .State) "Running") (eq (sessionStateName .State) "Starting")}}
+        {{$state := sessionStateName .State}}
+        {{if or (eq $state "Running") (eq $state "Starting") (eq $state "Stalled")}}
         <button hx-delete="/api/sessions/{{.ID}}"
                 hx-target="#session-table-body"
                 hx-swap="innerHTML"

--- a/internal/web/templates/partials/stats.html
+++ b/internal/web/templates/partials/stats.html
@@ -15,6 +15,10 @@
     <div class="bg-slate-800 rounded-lg border border-slate-700 p-4 shadow-lg">
         <div class="text-xs text-slate-400 uppercase tracking-wider mb-1">Daemon Uptime</div>
         <div class="text-2xl font-bold text-slate-200">{{.Uptime}}</div>
+        <div class="flex items-center space-x-1.5 mt-2 text-xs text-slate-400">
+            <span class="heartbeat-pulse inline-block w-2 h-2 rounded-full bg-green-500"></span>
+            <span>Updated {{.LastUpdate}}</span>
+        </div>
     </div>
 
     <!-- Sparkline -->

--- a/src/docs/modules/ROOT/pages/port-forwarding.adoc
+++ b/src/docs/modules/ROOT/pages/port-forwarding.adoc
@@ -153,6 +153,16 @@ gossm connect -p production -t i-0123456789abcdef0 \
 When managed by the daemon, tunnels appear on the xref:daemon.adoc#dashboard[web dashboard] and
 can be stopped from the browser.
 
+== Tunnel liveness
+
+Port-forward sessions are probed every 30 seconds by the daemon. The probe opens a short TCP connection to `127.0.0.1:<local-port>` with a 2-second timeout and records the outcome on the session.
+
+The dashboard surfaces the result under the status cell as `probe: ok 12s ago` or `probe: fail 4s ago`. A run of failures flips the session into the *Stalled* state (amber dot) so you can tell at a glance that the tunnel is no longer carrying traffic, even when the local `session-manager-plugin` process is still running.
+
+The probe doubles as keepalive traffic: most networks will not idle-out a tunnel that sees a TCP connection every 30 seconds, so this also reduces the rate at which AWS Session Manager closes idle sessions.
+
+Stalled sessions can be stopped from the dashboard like any other session. Probing is not performed for shell sessions; their status cell shows `probe: —`.
+
 == Flags Reference
 
 For the full list of flags available to the `connect` command (including port-forwarding flags),


### PR DESCRIPTION
## Summary

- Adds an active TCP probe (every 30s, 2s timeout) to port-forward sessions so the daemon detects when AWS has torn down a tunnel even though the local `session-manager-plugin` process is still running. The dashboard now flips silently-dead sessions to a *Stalled* state (amber dot) instead of leaving them looking healthy.
- Probe doubles as keepalive — most networks will not idle-out a tunnel that sees a TCP connection every 30s, so it also reduces the rate at which AWS Session Manager closes idle sessions.
- Surfaces probe status on each port-forward row as `probe: ok 12s ago` / `probe: fail 4s ago` / `pending`, plus a dashboard-level heartbeat indicator (server-rendered timestamp + CSS pulse) so a frozen page is visually distinguishable from a healthy one.
- Fixes a pre-existing bug where `StartSession` left sessions in `StateStarting` forever — the dashboard showed a yellow Starting indicator even when the tunnel was up.
- New Antora docs section under `port-forwarding.adoc` describing the probe behaviour.

## Notable design choices

- Probe targets `127.0.0.1:<local-port>` with `net.Dialer.DialContext`. A successful connect doesn't prove the upstream is healthy, but over time dial failures correlate strongly with tunnel teardown because the AWS plugin closes its listener when the SSM control channel is lost.
- Probe runs once immediately on session start, then on a 30s ticker. No 30-second "pending" gap before the first result.
- Shell sessions are not probed (no clean way without clobbering stdin); their probe column shows `—`.
- Probe-only state changes are emitted on transitions only (Running ↔ Stalled), not on every probe — avoids SSE flood.
- Heartbeat dot uses a one-shot CSS keyframe that re-runs each time HTMX swaps the stats partial. Frozen dashboard = static dot + frozen timestamp.

## Test plan

- [x] `go test -race ./...` — all packages green (28 session tests, 56 web tests)
- [x] `go vet ./...` — clean
- [x] `go mod tidy` — no diff
- [x] `go build` — builds clean
- [x] Antora docs build clean
- [x] Manual smoke (confirmed by reporter): "probe: ok 1s ago" appears within seconds of starting a port-forward; row shows green "Running" not yellow "Starting"
- [ ] Soak test: leave a port-forward idle overnight; confirm it survives AWS's 20-min idle timeout (this is the main hypothesis the keepalive side-effect rests on)

## Suggested release

This adds a user-visible feature plus a UI bug fix — feels like a `v0.4` to me. After merge: `git tag v0.4 && git push origin v0.4 && goreleaser release --clean`.