### PR TITLE
Auto-reconnect for stalled or crashed port-forward tunnels

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // SessionPreset defines a saved session that can be started from the dashboard.
@@ -28,6 +29,16 @@ type Config struct {
 	LogLevel      string
 	PIDDir        string
 
+	// Tunnel liveness probe knobs.
+	ProbeInterval time.Duration
+	ProbeTimeout  time.Duration
+
+	// Reconnect policy for daemon-managed port-forward sessions.
+	ReconnectFailureThreshold int
+	ReconnectMaxAttempts      int
+	ReconnectBackoffInitial   time.Duration
+	ReconnectBackoffMax       time.Duration
+
 	// Saved session presets loaded from config files.
 	Presets []SessionPreset
 }
@@ -36,9 +47,15 @@ type Config struct {
 func DefaultConfig() *Config {
 	home, _ := os.UserHomeDir()
 	return &Config{
-		DashboardPort: 8877,
-		LogLevel:      "warn",
-		PIDDir:        filepath.Join(home, ".gossm"),
+		DashboardPort:             8877,
+		LogLevel:                  "warn",
+		PIDDir:                    filepath.Join(home, ".gossm"),
+		ProbeInterval:             30 * time.Second,
+		ProbeTimeout:              2 * time.Second,
+		ReconnectFailureThreshold: 1,
+		ReconnectMaxAttempts:      5,
+		ReconnectBackoffInitial:   5 * time.Second,
+		ReconnectBackoffMax:       60 * time.Second,
 	}
 }
 
@@ -99,6 +116,30 @@ func applyKeyValue(key, value string, cfg *Config) {
 		cfg.LogLevel = value
 	case "GOSSM_PID_DIR":
 		cfg.PIDDir = value
+	case "GOSSM_PROBE_INTERVAL":
+		if d, err := time.ParseDuration(value); err == nil && d > 0 {
+			cfg.ProbeInterval = d
+		}
+	case "GOSSM_PROBE_TIMEOUT":
+		if d, err := time.ParseDuration(value); err == nil && d > 0 {
+			cfg.ProbeTimeout = d
+		}
+	case "GOSSM_RECONNECT_FAILURE_THRESHOLD":
+		if n, err := strconv.Atoi(value); err == nil && n > 0 {
+			cfg.ReconnectFailureThreshold = n
+		}
+	case "GOSSM_RECONNECT_MAX_ATTEMPTS":
+		if n, err := strconv.Atoi(value); err == nil && n > 0 {
+			cfg.ReconnectMaxAttempts = n
+		}
+	case "GOSSM_RECONNECT_BACKOFF_INITIAL":
+		if d, err := time.ParseDuration(value); err == nil && d > 0 {
+			cfg.ReconnectBackoffInitial = d
+		}
+	case "GOSSM_RECONNECT_BACKOFF_MAX":
+		if d, err := time.ParseDuration(value); err == nil && d > 0 {
+			cfg.ReconnectBackoffMax = d
+		}
 	default:
 		// Handle session presets: GOSSM_SESSION_<N>_<FIELD>=value
 		applyPresetKey(key, value, cfg)
@@ -164,6 +205,36 @@ func applyEnv(cfg *Config) {
 		},
 		"GOSSM_PID_DIR": func(v string) {
 			cfg.PIDDir = v
+		},
+		"GOSSM_PROBE_INTERVAL": func(v string) {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				cfg.ProbeInterval = d
+			}
+		},
+		"GOSSM_PROBE_TIMEOUT": func(v string) {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				cfg.ProbeTimeout = d
+			}
+		},
+		"GOSSM_RECONNECT_FAILURE_THRESHOLD": func(v string) {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.ReconnectFailureThreshold = n
+			}
+		},
+		"GOSSM_RECONNECT_MAX_ATTEMPTS": func(v string) {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.ReconnectMaxAttempts = n
+			}
+		},
+		"GOSSM_RECONNECT_BACKOFF_INITIAL": func(v string) {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				cfg.ReconnectBackoffInitial = d
+			}
+		},
+		"GOSSM_RECONNECT_BACKOFF_MAX": func(v string) {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				cfg.ReconnectBackoffMax = d
+			}
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,101 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestDefaultConfig_ProbeAndReconnectDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.ProbeInterval != 30*time.Second {
+		t.Errorf("ProbeInterval = %v, want 30s", cfg.ProbeInterval)
+	}
+	if cfg.ProbeTimeout != 2*time.Second {
+		t.Errorf("ProbeTimeout = %v, want 2s", cfg.ProbeTimeout)
+	}
+	if cfg.ReconnectFailureThreshold != 1 {
+		t.Errorf("ReconnectFailureThreshold = %d, want 1", cfg.ReconnectFailureThreshold)
+	}
+	if cfg.ReconnectMaxAttempts != 5 {
+		t.Errorf("ReconnectMaxAttempts = %d, want 5", cfg.ReconnectMaxAttempts)
+	}
+	if cfg.ReconnectBackoffInitial != 5*time.Second {
+		t.Errorf("ReconnectBackoffInitial = %v, want 5s", cfg.ReconnectBackoffInitial)
+	}
+	if cfg.ReconnectBackoffMax != 60*time.Second {
+		t.Errorf("ReconnectBackoffMax = %v, want 60s", cfg.ReconnectBackoffMax)
+	}
+}
+
+func TestLoadKeyValueFile_ProbeAndReconnect(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config")
+
+	content := `GOSSM_PROBE_INTERVAL=15s
+GOSSM_PROBE_TIMEOUT=500ms
+GOSSM_RECONNECT_FAILURE_THRESHOLD=3
+GOSSM_RECONNECT_MAX_ATTEMPTS=8
+GOSSM_RECONNECT_BACKOFF_INITIAL=2s
+GOSSM_RECONNECT_BACKOFF_MAX=2m
+`
+	if err := os.WriteFile(cfgFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	loadKeyValueFile(cfgFile, cfg)
+
+	if cfg.ProbeInterval != 15*time.Second {
+		t.Errorf("ProbeInterval = %v, want 15s", cfg.ProbeInterval)
+	}
+	if cfg.ProbeTimeout != 500*time.Millisecond {
+		t.Errorf("ProbeTimeout = %v, want 500ms", cfg.ProbeTimeout)
+	}
+	if cfg.ReconnectFailureThreshold != 3 {
+		t.Errorf("ReconnectFailureThreshold = %d, want 3", cfg.ReconnectFailureThreshold)
+	}
+	if cfg.ReconnectMaxAttempts != 8 {
+		t.Errorf("ReconnectMaxAttempts = %d, want 8", cfg.ReconnectMaxAttempts)
+	}
+	if cfg.ReconnectBackoffInitial != 2*time.Second {
+		t.Errorf("ReconnectBackoffInitial = %v, want 2s", cfg.ReconnectBackoffInitial)
+	}
+	if cfg.ReconnectBackoffMax != 2*time.Minute {
+		t.Errorf("ReconnectBackoffMax = %v, want 2m", cfg.ReconnectBackoffMax)
+	}
+}
+
+func TestLoadKeyValueFile_InvalidDurationIgnored(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config")
+
+	content := "GOSSM_PROBE_INTERVAL=not-a-duration\n"
+	if err := os.WriteFile(cfgFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig()
+	loadKeyValueFile(cfgFile, cfg)
+
+	if cfg.ProbeInterval != 30*time.Second {
+		t.Errorf("ProbeInterval = %v, want 30s (default preserved on invalid input)", cfg.ProbeInterval)
+	}
+}
+
+func TestApplyEnv_ProbeAndReconnect(t *testing.T) {
+	t.Setenv("GOSSM_PROBE_INTERVAL", "10s")
+	t.Setenv("GOSSM_RECONNECT_MAX_ATTEMPTS", "7")
+
+	cfg := DefaultConfig()
+	applyEnv(cfg)
+
+	if cfg.ProbeInterval != 10*time.Second {
+		t.Errorf("ProbeInterval = %v, want 10s", cfg.ProbeInterval)
+	}
+	if cfg.ReconnectMaxAttempts != 7 {
+		t.Errorf("ReconnectMaxAttempts = %d, want 7", cfg.ReconnectMaxAttempts)
+	}
+}
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -67,6 +67,15 @@ func Start(cfg *config.Config) (*Daemon, error) {
 	}
 
 	sm := session.New(nil, isProcessAlive)
+	// Apply probe and reconnect knobs from the loaded config so the
+	// daemon honours .env / env-var overrides.
+	sm.SetProbeTimings(cfg.ProbeInterval, cfg.ProbeTimeout)
+	sm.SetReconnectPolicy(
+		cfg.ReconnectFailureThreshold,
+		cfg.ReconnectMaxAttempts,
+		cfg.ReconnectBackoffInitial,
+		cfg.ReconnectBackoffMax,
+	)
 
 	d := &Daemon{
 		cfg:       cfg,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -53,9 +53,17 @@ type SessionManager struct {
 	prober        Prober
 	probeInterval time.Duration
 	probeTimeout  time.Duration
-	sparkData     []int // ring buffer of active session counts, last 60 entries
-	sparkIndex    int
-	stopCh        chan struct{}
+
+	// Reconnect policy. Configured via SetReconnectPolicy.
+	reconnectFailureThreshold int           // consecutive probe failures before triggering reconnect
+	reconnectMaxAttempts      int           // give up after this many failed respawn attempts
+	reconnectBackoffInitial   time.Duration // first inter-attempt sleep
+	reconnectBackoffMax       time.Duration // upper bound on backoff sleep
+	sleep                     func(time.Duration)
+
+	sparkData  []int // ring buffer of active session counts, last 60 entries
+	sparkIndex int
+	stopCh     chan struct{}
 }
 
 // New creates a SessionManager.  If builder is nil the default AWS CLI
@@ -66,15 +74,49 @@ func New(builder CommandBuilder, checker ProcessChecker) *SessionManager {
 		builder = defaultCommandBuilder
 	}
 	return &SessionManager{
-		sessions:      make(map[string]*Session),
-		OnChange:      make(chan SessionEvent, 64),
-		buildCommand:  builder,
-		checkProcess:  checker,
-		prober:        defaultTCPProber,
-		probeInterval: 30 * time.Second,
-		probeTimeout:  2 * time.Second,
-		sparkData:     make([]int, 60),
-		stopCh:        make(chan struct{}),
+		sessions:                  make(map[string]*Session),
+		OnChange:                  make(chan SessionEvent, 64),
+		buildCommand:              builder,
+		checkProcess:              checker,
+		prober:                    defaultTCPProber,
+		probeInterval:             30 * time.Second,
+		probeTimeout:              2 * time.Second,
+		reconnectFailureThreshold: 1,
+		reconnectMaxAttempts:      5,
+		reconnectBackoffInitial:   5 * time.Second,
+		reconnectBackoffMax:       60 * time.Second,
+		sleep:                     time.Sleep,
+		sparkData:                 make([]int, 60),
+		stopCh:                    make(chan struct{}),
+	}
+}
+
+// SetReconnectPolicy overrides the reconnect parameters. Pass zero for any
+// value to keep the existing default for that knob.
+func (m *SessionManager) SetReconnectPolicy(failureThreshold, maxAttempts int, backoffInitial, backoffMax time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if failureThreshold > 0 {
+		m.reconnectFailureThreshold = failureThreshold
+	}
+	if maxAttempts > 0 {
+		m.reconnectMaxAttempts = maxAttempts
+	}
+	if backoffInitial > 0 {
+		m.reconnectBackoffInitial = backoffInitial
+	}
+	if backoffMax > 0 {
+		m.reconnectBackoffMax = backoffMax
+	}
+}
+
+// SetSleeper replaces the manager's sleep function. Intended for tests
+// so reconnect backoff sequences can be exercised deterministically.
+func (m *SessionManager) SetSleeper(s func(time.Duration)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s != nil {
+		m.sleep = s
 	}
 }
 
@@ -86,6 +128,20 @@ func (m *SessionManager) SetProbe(p Prober, interval, timeout time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.prober = p
+	if interval > 0 {
+		m.probeInterval = interval
+	}
+	if timeout > 0 {
+		m.probeTimeout = timeout
+	}
+}
+
+// SetProbeTimings updates the probe interval and timeout without
+// touching the installed prober. Pass zero for either value to keep
+// the existing default for that knob.
+func (m *SessionManager) SetProbeTimings(interval, timeout time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if interval > 0 {
 		m.probeInterval = interval
 	}
@@ -121,19 +177,20 @@ func (m *SessionManager) StartSession(opts SessionOpts) (string, error) {
 	cmd := m.buildCommand(ctx, opts)
 
 	s := &Session{
-		ID:           id,
-		InstanceID:   opts.InstanceID,
-		InstanceName: opts.InstanceName,
-		Profile:      opts.Profile,
-		Type:         opts.Type,
-		State:        StateStarting,
-		LocalPort:    opts.LocalPort,
-		RemotePort:   opts.RemotePort,
-		RemoteHost:   opts.RemoteHost,
-		StartedAt:    time.Now(),
-		cmd:          cmd,
-		cancel:       cancel,
-		waitDone:     make(chan struct{}),
+		ID:            id,
+		InstanceID:    opts.InstanceID,
+		InstanceName:  opts.InstanceName,
+		Profile:       opts.Profile,
+		Type:          opts.Type,
+		State:         StateStarting,
+		LocalPort:     opts.LocalPort,
+		RemotePort:    opts.RemotePort,
+		RemoteHost:    opts.RemoteHost,
+		StartedAt:     time.Now(),
+		cmd:           cmd,
+		cancel:        cancel,
+		waitDone:      make(chan struct{}),
+		Reconnectable: opts.Type == TypePortForward,
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -151,7 +208,7 @@ func (m *SessionManager) StartSession(opts SessionOpts) (string, error) {
 	m.emit(SessionEvent{Type: "added", SessionID: id, Timestamp: time.Now()})
 
 	// Monitor the subprocess in the background.
-	go m.monitor(s)
+	go m.monitor(s, cmd, s.waitDone)
 
 	// Probe the tunnel for liveness if this is a port-forward session.
 	if s.Type == TypePortForward {
@@ -162,20 +219,50 @@ func (m *SessionManager) StartSession(opts SessionOpts) (string, error) {
 }
 
 // monitor waits for the subprocess to finish and updates state accordingly.
-func (m *SessionManager) monitor(s *Session) {
-	err := s.cmd.Wait()
-	close(s.waitDone)
+// cmd and waitDone are passed in so each monitor goroutine owns its own
+// subprocess: after a reconnect, the previous monitor closes its OWN
+// waitDone (not the new one) and exits without disturbing the new state.
+func (m *SessionManager) monitor(s *Session, cmd *exec.Cmd, waitDone chan struct{}) {
+	err := cmd.Wait()
+	close(waitDone)
 
 	m.mu.Lock()
-	if err != nil {
-		s.State = StateErrored
-		s.LastError = err.Error()
-	} else {
+	// If a reconnect cycle has already taken charge of this session, do
+	// not override the state it has set.
+	if s.State == StateReconnecting {
+		m.mu.Unlock()
+		return
+	}
+	// User asked us to stop — record that and we're done.
+	if s.State == StateStopping {
 		s.State = StateStopped
+		m.mu.Unlock()
+		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+		return
+	}
+	// For non-reconnectable sessions (shells, externally registered),
+	// preserve the original behaviour: terminal state on exit.
+	if !s.Reconnectable {
+		if err != nil {
+			s.State = StateErrored
+			s.LastError = err.Error()
+		} else {
+			s.State = StateStopped
+		}
+		m.mu.Unlock()
+		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+		return
+	}
+	// Reconnectable session, unexpected exit — flag stalled and ask the
+	// reconnect loop to take over.
+	s.State = StateStalled
+	if err != nil {
+		s.LastError = err.Error()
 	}
 	m.mu.Unlock()
-
 	m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+
+	m.triggerReconnect(s, false)
 }
 
 // monitorExternalPID polls the PID of an externally registered session
@@ -212,21 +299,26 @@ func (m *SessionManager) StopSession(id string) error {
 		return fmt.Errorf("session %s not found", id)
 	}
 	s.State = StateStopping
+	// Snapshot subprocess handles under the lock — these fields can be
+	// rewritten by runReconnectLoop during a reconnect cycle.
+	cancel := s.cancel
+	waitDone := s.waitDone
+	cmd := s.cmd
 	m.mu.Unlock()
 
 	// Signal the subprocess via context cancellation.
-	if s.cancel != nil {
-		s.cancel()
+	if cancel != nil {
+		cancel()
 	}
 
 	// Wait for the monitor goroutine to observe the exit, or kill after timeout.
-	if s.waitDone != nil {
+	if waitDone != nil {
 		select {
-		case <-s.waitDone:
+		case <-waitDone:
 			// exited cleanly
 		case <-time.After(5 * time.Second):
-			if s.cmd != nil && s.cmd.Process != nil {
-				_ = s.cmd.Process.Kill()
+			if cmd != nil && cmd.Process != nil {
+				_ = cmd.Process.Kill()
 			}
 		}
 	}
@@ -366,14 +458,17 @@ func (m *SessionManager) emit(e SessionEvent) {
 // Stalled → probe-succeeds edge it transitions back to Running. The
 // goroutine exits when the session leaves an active state, when stopCh
 // is closed, or when the prober is nil.
+//
+// The effective interval between probes is read fresh on every tick so
+// runtime per-session updates via SetSessionProbeInterval take effect
+// without restarting the goroutine.
 func (m *SessionManager) monitorProbe(s *Session) {
 	m.mu.RLock()
-	interval := m.probeInterval
-	timeout := m.probeTimeout
 	prober := m.prober
+	timeout := m.probeTimeout
 	m.mu.RUnlock()
 
-	if prober == nil || interval <= 0 {
+	if prober == nil {
 		return
 	}
 
@@ -383,19 +478,58 @@ func (m *SessionManager) monitorProbe(s *Session) {
 		return
 	}
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
 	for {
+		interval := m.effectiveProbeInterval(s)
+		if interval <= 0 {
+			return
+		}
+		t := time.NewTimer(interval)
 		select {
 		case <-m.stopCh:
+			t.Stop()
 			return
-		case <-ticker.C:
+		case <-t.C:
+			m.mu.RLock()
+			prober = m.prober
+			timeout = m.probeTimeout
+			m.mu.RUnlock()
+			if prober == nil {
+				return
+			}
 			if !m.runProbe(s, prober, timeout) {
 				return
 			}
 		}
 	}
+}
+
+// effectiveProbeInterval returns the per-session ProbeInterval if it's
+// set, otherwise the manager-wide default.
+func (m *SessionManager) effectiveProbeInterval(s *Session) time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if cur, ok := m.sessions[s.ID]; ok && cur.ProbeInterval > 0 {
+		return cur.ProbeInterval
+	}
+	return m.probeInterval
+}
+
+// EffectiveProbeInterval is the public view of effectiveProbeInterval.
+// The web layer uses it to render the current interval per row.
+func (m *SessionManager) EffectiveProbeInterval(id string) time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if cur, ok := m.sessions[id]; ok && cur.ProbeInterval > 0 {
+		return cur.ProbeInterval
+	}
+	return m.probeInterval
+}
+
+// DefaultProbeInterval returns the manager-wide probe interval default.
+func (m *SessionManager) DefaultProbeInterval() time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.probeInterval
 }
 
 // runProbe executes a single probe against s and applies the result to
@@ -422,19 +556,223 @@ func (m *SessionManager) runProbe(s *Session, prober Prober, timeout time.Durati
 	cur.LastProbeOK = ok
 
 	stateChanged := false
+	shouldReconnect := false
 	switch {
 	case !ok && cur.State == StateRunning:
 		cur.State = StateStalled
+		cur.consecutiveFailures++
 		stateChanged = true
+		if cur.Reconnectable && cur.consecutiveFailures >= m.reconnectFailureThreshold {
+			shouldReconnect = true
+		}
+	case !ok && cur.State == StateStalled:
+		cur.consecutiveFailures++
+		if cur.Reconnectable && cur.consecutiveFailures >= m.reconnectFailureThreshold {
+			shouldReconnect = true
+		}
 	case ok && cur.State == StateStalled:
 		cur.State = StateRunning
+		cur.consecutiveFailures = 0
+		cur.ReconnectAttempts = 0
 		stateChanged = true
+	case ok && cur.State == StateRunning:
+		cur.consecutiveFailures = 0
+		cur.ReconnectAttempts = 0
 	}
 	m.mu.Unlock()
 
 	if stateChanged {
 		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
 	}
+	if shouldReconnect {
+		m.triggerReconnect(s, false)
+	}
 	return true
+}
+
+// triggerReconnect schedules a reconnect cycle for s. Only one cycle
+// runs at a time per session; concurrent triggers while a cycle is
+// already in flight are dropped (manual triggers reset the attempt
+// counter so they still take effect on the in-flight cycle).
+func (m *SessionManager) triggerReconnect(s *Session, manual bool) {
+	m.mu.Lock()
+	if !s.Reconnectable {
+		m.mu.Unlock()
+		return
+	}
+	if manual {
+		s.ReconnectAttempts = 0
+	}
+	if s.reconnectInFlight {
+		m.mu.Unlock()
+		return
+	}
+	s.reconnectInFlight = true
+	m.mu.Unlock()
+
+	go m.runReconnectLoop(s)
+}
+
+// runReconnectLoop keeps respawning the session's subprocess until it
+// either succeeds (state returns to StateRunning) or the configured
+// maximum number of attempts is exhausted (state becomes StateErrored).
+// Backoff between attempts doubles from the initial value to the
+// configured max.
+func (m *SessionManager) runReconnectLoop(s *Session) {
+	defer func() {
+		m.mu.Lock()
+		s.reconnectInFlight = false
+		m.mu.Unlock()
+	}()
+
+	for {
+		m.mu.Lock()
+		if s.State == StateStopping || s.State == StateStopped {
+			m.mu.Unlock()
+			return
+		}
+		if _, exists := m.sessions[s.ID]; !exists {
+			m.mu.Unlock()
+			return
+		}
+		attempt := s.ReconnectAttempts + 1
+		if attempt > m.reconnectMaxAttempts {
+			s.State = StateErrored
+			if s.LastError == "" {
+				s.LastError = fmt.Sprintf("reconnect exhausted after %d attempts", m.reconnectMaxAttempts)
+			}
+			m.mu.Unlock()
+			m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+			return
+		}
+		opts := optsFromSession(s)
+		oldCmd := s.cmd
+		oldCancel := s.cancel
+		oldWaitDone := s.waitDone
+		backoffInitial := m.reconnectBackoffInitial
+		backoffMax := m.reconnectBackoffMax
+		s.State = StateReconnecting
+		s.ReconnectAttempts = attempt
+		s.LastReconnectAt = time.Now()
+		m.mu.Unlock()
+		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+
+		// Stop the old subprocess if any. Wait briefly for the old
+		// monitor to clean up, but do not block forever.
+		if oldCancel != nil {
+			oldCancel()
+		}
+		if oldWaitDone != nil {
+			select {
+			case <-oldWaitDone:
+			case <-time.After(5 * time.Second):
+				if oldCmd != nil && oldCmd.Process != nil {
+					_ = oldCmd.Process.Kill()
+				}
+			}
+		}
+
+		// Build and start a fresh subprocess with the same opts.
+		ctx, cancel := context.WithCancel(context.Background())
+		newCmd := m.buildCommand(ctx, opts)
+		startErr := newCmd.Start()
+		if startErr != nil {
+			cancel()
+			m.mu.Lock()
+			s.LastError = fmt.Sprintf("reconnect attempt %d: %v", attempt, startErr)
+			m.mu.Unlock()
+			m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+
+			// Sleep with backoff, then loop.
+			m.sleep(reconnectBackoff(attempt, backoffInitial, backoffMax))
+			continue
+		}
+
+		// Success — install the new subprocess on the session.
+		newWaitDone := make(chan struct{})
+		m.mu.Lock()
+		s.cmd = newCmd
+		s.cancel = cancel
+		s.waitDone = newWaitDone
+		s.PID = newCmd.Process.Pid
+		s.State = StateRunning
+		s.consecutiveFailures = 0
+		// ReconnectAttempts is left non-zero until a successful probe
+		// confirms the tunnel is healthy; that lets us track repeated
+		// flapping and eventually give up if it keeps failing.
+		m.mu.Unlock()
+		m.emit(SessionEvent{Type: "updated", SessionID: s.ID, Timestamp: time.Now()})
+
+		go m.monitor(s, newCmd, newWaitDone)
+		return
+	}
+}
+
+// reconnectBackoff returns the delay for the n-th reconnect attempt
+// (1-indexed). The sequence doubles from initial up to max.
+func reconnectBackoff(attempt int, initial, max time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := initial
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= max {
+			return max
+		}
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+// optsFromSession reconstructs the SessionOpts that drive the
+// command builder for a respawn. Caller must hold m.mu.
+func optsFromSession(s *Session) SessionOpts {
+	return SessionOpts{
+		InstanceID:   s.InstanceID,
+		InstanceName: s.InstanceName,
+		Profile:      s.Profile,
+		Type:         s.Type,
+		LocalPort:    s.LocalPort,
+		RemotePort:   s.RemotePort,
+		RemoteHost:   s.RemoteHost,
+	}
+}
+
+// ManualReconnect resets the attempt counter and triggers a reconnect
+// cycle for the named session. Returns an error if the session is
+// missing or not reconnectable.
+func (m *SessionManager) ManualReconnect(id string) error {
+	m.mu.RLock()
+	s, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("session %s not found", id)
+	}
+	if !s.Reconnectable {
+		return fmt.Errorf("session %s is not reconnectable", id)
+	}
+	m.triggerReconnect(s, true)
+	return nil
+}
+
+// SetSessionProbeInterval updates the per-session probe interval. The
+// new interval must be between 1 second and 10 minutes.
+func (m *SessionManager) SetSessionProbeInterval(id string, d time.Duration) error {
+	if d < time.Second || d > 10*time.Minute {
+		return fmt.Errorf("probe interval %s out of range (must be between 1s and 10m)", d)
+	}
+	m.mu.Lock()
+	s, ok := m.sessions[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("session %s not found", id)
+	}
+	s.ProbeInterval = d
+	m.mu.Unlock()
+	m.emit(SessionEvent{Type: "updated", SessionID: id, Timestamp: time.Now()})
+	return nil
 }
 

--- a/internal/session/manager_reconnect_test.go
+++ b/internal/session/manager_reconnect_test.go
@@ -1,0 +1,407 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordingBuilder counts builder calls and lets the test choose the
+// command produced for each call.
+type recordingBuilder struct {
+	mu    sync.Mutex
+	calls int32
+	fns   []func(ctx context.Context) *exec.Cmd
+}
+
+func (b *recordingBuilder) Builder() CommandBuilder {
+	return func(ctx context.Context, opts SessionOpts) *exec.Cmd {
+		atomic.AddInt32(&b.calls, 1)
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		idx := int(atomic.LoadInt32(&b.calls)) - 1
+		if idx < len(b.fns) && b.fns[idx] != nil {
+			return b.fns[idx](ctx)
+		}
+		return exec.CommandContext(ctx, "sleep", "3600")
+	}
+}
+
+func (b *recordingBuilder) Calls() int { return int(atomic.LoadInt32(&b.calls)) }
+
+func waitForCalls(b *recordingBuilder, want int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b.Calls() >= want {
+			return nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return errors.New("timeout waiting for builder calls")
+}
+
+// quickExitBuilder returns a builder whose first call exits with error
+// almost immediately, and subsequent calls produce long-running sleeps.
+// This simulates an SSM subprocess that crashes shortly after launch.
+func quickExitBuilder(b *recordingBuilder) {
+	b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+		// Force an error exit so monitor() takes the unexpected-exit path.
+		return exec.CommandContext(ctx, "false")
+	})
+}
+
+// TestReconnect_OnUnexpectedExit_RespawnsSubprocess verifies that when
+// the SSM subprocess exits unexpectedly (non-zero, not user-initiated),
+// the manager kicks off a reconnect cycle that builds a new command.
+func TestReconnect_OnUnexpectedExit_RespawnsSubprocess(t *testing.T) {
+	b := &recordingBuilder{}
+	quickExitBuilder(b)
+	// Subsequent calls fall through to the default sleep 3600.
+
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 5, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	defer sm.Close()
+
+	// Disable probes so the only reconnect signal is unexpected exit.
+	sm.SetProbe(nil, 0, 0)
+
+	if _, err := sm.StartSession(portForwardOpts("reconn-exit", 13302)); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if err := waitForCalls(b, 2, 2*time.Second); err != nil {
+		t.Fatalf("expected reconnect after unexpected exit: %v", err)
+	}
+}
+
+// TestReconnect_OnUserStop_DoesNotRespawn verifies that StopSession
+// (user-initiated) does not trigger a reconnect.
+func TestReconnect_OnUserStop_DoesNotRespawn(t *testing.T) {
+	b := &recordingBuilder{}
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 5, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	defer sm.Close()
+	sm.SetProbe(nil, 0, 0)
+
+	id, err := sm.StartSession(portForwardOpts("reconn-stop", 13303))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if err := waitForCalls(b, 1, time.Second); err != nil {
+		t.Fatalf("initial spawn: %v", err)
+	}
+
+	if err := sm.StopSession(id); err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+
+	// Wait for any rogue reconnect to (not) happen.
+	time.Sleep(300 * time.Millisecond)
+
+	if b.Calls() != 1 {
+		t.Errorf("builder called %d times; expected exactly 1 (no reconnect on user stop)", b.Calls())
+	}
+}
+
+// TestReconnect_RespectsMaxAttempts verifies that when every respawn
+// fails to start, the loop gives up after maxAttempts and ends in
+// StateErrored.
+func TestReconnect_RespectsMaxAttempts(t *testing.T) {
+	b := &recordingBuilder{}
+	// Initial succeeds, every respawn afterwards fails to start.
+	b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "3600")
+	})
+	for i := 0; i < 10; i++ {
+		b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+			return exec.CommandContext(ctx, "/this/binary/does/not/exist")
+		})
+	}
+
+	var slept atomic.Int32
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 3, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) { slept.Add(1) })
+	defer sm.Close()
+	sm.SetProbe(nil, 0, 0)
+
+	id, err := sm.StartSession(portForwardOpts("reconn-max", 13304))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Trigger a reconnect manually since we disabled probing.
+	if err := sm.ManualReconnect(id); err != nil {
+		t.Fatalf("ManualReconnect: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s, _ := sm.GetSession(id)
+		if s.State == StateErrored {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s, _ := sm.GetSession(id)
+	if s.State != StateErrored {
+		t.Fatalf("state = %d, want StateErrored after exhausting attempts", s.State)
+	}
+	// Initial + 3 retries = 4 builder calls.
+	if got := b.Calls(); got != 4 {
+		t.Errorf("builder calls = %d, want 4 (initial + 3 max attempts)", got)
+	}
+	if s.ReconnectAttempts != 3 {
+		t.Errorf("ReconnectAttempts = %d, want 3", s.ReconnectAttempts)
+	}
+}
+
+// TestReconnect_NotReconnectableForExternal verifies that externally
+// registered sessions (CLI-launched, daemon does not own the process)
+// are never reconnected even when their probe fails.
+func TestReconnect_NotReconnectableForExternal(t *testing.T) {
+	b := &recordingBuilder{}
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 5, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	defer sm.Close()
+
+	var fail atomic.Bool
+	fail.Store(true)
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		return !fail.Load()
+	}, 20*time.Millisecond, 50*time.Millisecond)
+
+	id := sm.RegisterExternal(portForwardOpts("ext-noreconn", 13305), 99999)
+
+	// Wait long enough for a few probes.
+	time.Sleep(200 * time.Millisecond)
+
+	s, ok := sm.GetSession(id)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if s.Reconnectable {
+		t.Errorf("external session must not be Reconnectable")
+	}
+	if b.Calls() != 0 {
+		t.Errorf("builder called %d times; external sessions must not be reconnected", b.Calls())
+	}
+}
+
+// TestReconnectBackoff_Sequence verifies the doubling backoff sequence
+// caps at the configured maximum.
+func TestReconnectBackoff_Sequence(t *testing.T) {
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 5 * time.Second},
+		{2, 10 * time.Second},
+		{3, 20 * time.Second},
+		{4, 40 * time.Second},
+		{5, 60 * time.Second}, // capped
+		{6, 60 * time.Second},
+	}
+	for _, c := range cases {
+		got := reconnectBackoff(c.attempt, 5*time.Second, 60*time.Second)
+		if got != c.want {
+			t.Errorf("reconnectBackoff(%d) = %v, want %v", c.attempt, got, c.want)
+		}
+	}
+}
+
+// TestManualReconnect_ResetsAttempts verifies that a manual reconnect
+// after attempts have been exhausted resets the counter and tries again.
+func TestManualReconnect_ResetsAttempts(t *testing.T) {
+	b := &recordingBuilder{}
+	// Initial spawn succeeds.
+	b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "3600")
+	})
+	// First reconnect attempt fails.
+	b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/this/binary/does/not/exist")
+	})
+	// Manual retry succeeds.
+	b.fns = append(b.fns, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "3600")
+	})
+
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 1, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	defer sm.Close()
+	sm.SetProbe(nil, 0, 0)
+
+	id, err := sm.StartSession(portForwardOpts("reconn-manual", 13306))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if err := sm.ManualReconnect(id); err != nil {
+		t.Fatalf("ManualReconnect: %v", err)
+	}
+
+	// Wait for the loop to give up (max=1 attempt, so it errors out fast).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s, _ := sm.GetSession(id)
+		if s.State == StateErrored {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s, _ := sm.GetSession(id)
+	if s.State != StateErrored {
+		t.Fatalf("state = %d, want StateErrored after exhausting attempts", s.State)
+	}
+
+	// Manually reconnect again — counter should reset and the third
+	// builder call should succeed.
+	if err := sm.ManualReconnect(id); err != nil {
+		t.Fatalf("second ManualReconnect: %v", err)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s, _ := sm.GetSession(id)
+		if s.State == StateRunning && b.Calls() == 3 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s, _ = sm.GetSession(id)
+	if s.State != StateRunning {
+		t.Fatalf("after manual reconnect, state = %d, want StateRunning", s.State)
+	}
+	if got := b.Calls(); got != 3 {
+		t.Errorf("builder calls = %d, want 3 (initial + failed + successful manual)", got)
+	}
+	if s.ReconnectAttempts != 1 {
+		t.Errorf("ReconnectAttempts = %d, want 1 after one successful manual respawn", s.ReconnectAttempts)
+	}
+}
+
+// TestSetSessionProbeInterval_AppliesOnNextTick verifies that updating
+// a session's ProbeInterval is honoured by the running probe loop.
+//
+// Bypasses SetSessionProbeInterval's user-facing 1s minimum (which is a
+// safety check for the dashboard, not the loop) by writing the field
+// directly so the test can assert on millisecond timing.
+func TestSetSessionProbeInterval_AppliesOnNextTick(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	var probes atomic.Int32
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		probes.Add(1)
+		return true
+	}, time.Hour, 50*time.Millisecond) // huge default so without override we'd see ~1 probe (immediate)
+
+	id, err := sm.StartSession(portForwardOpts("probe-interval", 13307))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// Override directly under the lock — same effect as
+	// SetSessionProbeInterval but skipping the public-API range check.
+	sm.mu.Lock()
+	sm.sessions[id].ProbeInterval = 30 * time.Millisecond
+	sm.mu.Unlock()
+
+	// Wait for several probes to fire under the new interval.
+	time.Sleep(250 * time.Millisecond)
+	if got := probes.Load(); got < 3 {
+		t.Errorf("probes = %d under 30ms interval; want >= 3 (fast override should be honoured)", got)
+	}
+
+	if got := sm.EffectiveProbeInterval(id); got != 30*time.Millisecond {
+		t.Errorf("EffectiveProbeInterval = %v, want 30ms", got)
+	}
+}
+
+// TestSetSessionProbeInterval_RejectsOutOfRange verifies validation.
+func TestSetSessionProbeInterval_RejectsOutOfRange(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+
+	id, err := sm.StartSession(portForwardOpts("probe-range", 13308))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if err := sm.SetSessionProbeInterval(id, 100*time.Millisecond); err == nil {
+		t.Errorf("expected error for interval < 1s")
+	}
+	if err := sm.SetSessionProbeInterval(id, 11*time.Minute); err == nil {
+		t.Errorf("expected error for interval > 10m")
+	}
+	if err := sm.SetSessionProbeInterval(id, 5*time.Second); err != nil {
+		t.Errorf("5s interval should be accepted, got %v", err)
+	}
+}
+
+// TestEffectiveProbeInterval_FallsBackToDefault verifies that when no
+// per-session override is set, EffectiveProbeInterval returns the
+// manager default.
+func TestEffectiveProbeInterval_FallsBackToDefault(t *testing.T) {
+	sm := New(sleepBuilder(), nil)
+	defer sm.Close()
+	sm.SetProbe(nil, 7*time.Second, 0)
+
+	id, err := sm.StartSession(portForwardOpts("probe-default", 13309))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	if got := sm.EffectiveProbeInterval(id); got != 7*time.Second {
+		t.Errorf("EffectiveProbeInterval = %v, want 7s (manager default)", got)
+	}
+}
+
+// TestReconnect_OnStall_RespawnsSubprocess verifies that a stalled
+// port-forward session triggers a reconnect that invokes the command
+// builder again to spawn a fresh subprocess.
+func TestReconnect_OnStall_RespawnsSubprocess(t *testing.T) {
+	b := &recordingBuilder{}
+	sm := New(b.Builder(), nil)
+	sm.SetReconnectPolicy(1, 5, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	defer sm.Close()
+
+	var fail atomic.Bool
+	sm.SetProbe(func(ctx context.Context, s *Session) bool {
+		return !fail.Load()
+	}, 20*time.Millisecond, 50*time.Millisecond)
+
+	id, err := sm.StartSession(portForwardOpts("reconn-stall", 13301))
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	// First builder call is the initial spawn.
+	if err := waitForCalls(b, 1, time.Second); err != nil {
+		t.Fatalf("initial spawn never built a command: %v", err)
+	}
+
+	// Daemon-spawned sessions must be marked Reconnectable.
+	s, _ := sm.GetSession(id)
+	if !s.Reconnectable {
+		t.Fatalf("daemon-started session should have Reconnectable=true")
+	}
+
+	// Trigger probe failure → stall → reconnect.
+	fail.Store(true)
+
+	if err := waitForCalls(b, 2, 2*time.Second); err != nil {
+		t.Fatalf("expected reconnect to invoke builder a second time: %v", err)
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -434,6 +434,18 @@ func TestStateStalledDistinct(t *testing.T) {
 	}
 }
 
+func TestStateReconnectingDistinct(t *testing.T) {
+	values := []SessionState{
+		StateStarting, StateRunning, StateStopping, StateStalled,
+		StateStopped, StateErrored,
+	}
+	for _, v := range values {
+		if StateReconnecting == v {
+			t.Fatalf("StateReconnecting collides with state value %d", v)
+		}
+	}
+}
+
 func TestDefaultTCPProberSucceedsOnLiveListener(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -564,6 +576,10 @@ func TestProbeFailureTransitionsToStalled(t *testing.T) {
 	sm := New(sleepBuilder(), nil)
 	defer sm.Close()
 
+	// Disable reconnect so the test observes the Running→Stalled edge
+	// without it being immediately consumed by a respawn.
+	sm.SetReconnectPolicy(1<<30, 1, time.Second, time.Second)
+
 	var fail atomic.Bool
 	sm.SetProbe(func(ctx context.Context, s *Session) bool {
 		return !fail.Load()
@@ -589,6 +605,9 @@ func TestProbeFailureTransitionsToStalled(t *testing.T) {
 func TestProbeRecoveryTransitionsBackToRunning(t *testing.T) {
 	sm := New(sleepBuilder(), nil)
 	defer sm.Close()
+
+	// Disable reconnect so the probe loop drives state transitions on its own.
+	sm.SetReconnectPolicy(1<<30, 1, time.Second, time.Second)
 
 	var fail atomic.Bool
 	sm.SetProbe(func(ctx context.Context, s *Session) bool {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -24,28 +24,35 @@ const (
 	StateStalled
 	StateStopped
 	StateErrored
+	StateReconnecting
 )
 
 // Session represents a single SSM session, including the underlying
 // subprocess that drives it.
 type Session struct {
-	ID           string
-	InstanceID   string
-	InstanceName string
-	Profile      string
-	Type         SessionType
-	State        SessionState
-	LocalPort    int    // port forwarding only
-	RemotePort   int    // port forwarding only
-	RemoteHost   string // port forwarding only
-	StartedAt    time.Time
-	LastError    string
-	PID          int       // PID of the aws ssm subprocess
-	LastProbeAt  time.Time // last time the tunnel probe ran (port-forward only)
-	LastProbeOK  bool      // outcome of the last probe (port-forward only)
-	cmd          *exec.Cmd
-	cancel       context.CancelFunc
-	waitDone     chan struct{} // closed when cmd.Wait() completes in monitor
+	ID                  string
+	InstanceID          string
+	InstanceName        string
+	Profile             string
+	Type                SessionType
+	State               SessionState
+	LocalPort           int    // port forwarding only
+	RemotePort          int    // port forwarding only
+	RemoteHost          string // port forwarding only
+	StartedAt           time.Time
+	LastError           string
+	PID                 int           // PID of the aws ssm subprocess
+	LastProbeAt         time.Time     // last time the tunnel probe ran (port-forward only)
+	LastProbeOK         bool          // outcome of the last probe (port-forward only)
+	ProbeInterval       time.Duration // per-session probe interval; zero falls back to manager default
+	Reconnectable       bool          // true if the manager owns the subprocess and may respawn it
+	ReconnectAttempts   int           // attempts in the current failure cycle; resets on probe success
+	LastReconnectAt     time.Time     // timestamp of the most recent reconnect attempt
+	consecutiveFailures int  // consecutive failed probes since the last success
+	reconnectInFlight   bool // guarded by SessionManager.mu; true while a reconnect cycle is running
+	cmd                 *exec.Cmd
+	cancel              context.CancelFunc
+	waitDone            chan struct{} // closed when cmd.Wait() completes in monitor
 }
 
 // SessionEvent is emitted whenever the session registry changes.

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -20,13 +20,27 @@ import (
 
 // DashboardData is the data passed to the dashboard template.
 type DashboardData struct {
-	Sessions     []session.Session
-	SessionCount int
-	Uptime       string
-	Port         int
-	SparkSVG     template.HTML
-	Presets      []config.SessionPreset
-	LastUpdate   string
+	ActiveSessions  []session.Session
+	StoppedSessions []session.Session
+	SessionCount    int
+	Uptime          string
+	Port            int
+	SparkSVG        template.HTML
+	Presets         []config.SessionPreset
+	LastUpdate      string
+}
+
+// splitSessions separates a session slice into active (live or
+// recovering) and stopped (terminal) lists.
+func splitSessions(all []session.Session) (active, stopped []session.Session) {
+	for _, s := range all {
+		if isActiveState(s.State) {
+			active = append(active, s)
+		} else {
+			stopped = append(stopped, s)
+		}
+	}
+	return
 }
 
 // handleDashboard renders the full dashboard page.
@@ -52,11 +66,16 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleSessionsList renders the session list partial.
+// handleSessionsList renders the session list partial. By default it
+// returns active sessions. Pass ?stopped=1 for the stopped/errored list.
 func (s *Server) handleSessionsList(w http.ResponseWriter, r *http.Request) {
-	sessions := s.sm.ListSessions()
+	active, stopped := splitSessions(s.sm.ListSessions())
+	list := active
+	if r != nil && r.URL.Query().Get("stopped") == "1" {
+		list = stopped
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := s.tmpl.ExecuteTemplate(w, "session_list.html", sessions); err != nil {
+	if err := s.tmpl.ExecuteTemplate(w, "session_list.html", list); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -112,6 +131,72 @@ func (s *Server) handleStopSession(w http.ResponseWriter, r *http.Request) {
 
 	// Return the updated session list.
 	s.handleSessionsList(w, r)
+}
+
+// handleReconnectSession kicks off a manual reconnect cycle for a
+// daemon-managed port-forward session.
+func (s *Server) handleReconnectSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "missing session id", http.StatusBadRequest)
+		return
+	}
+
+	if _, ok := s.sm.GetSession(id); !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	if err := s.sm.ManualReconnect(id); err != nil {
+		// Most often: session is not reconnectable (externally registered).
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.handleSessionsList(w, r)
+}
+
+// handleSetProbeInterval updates the per-session probe interval. The
+// interval form value is in seconds (1-600).
+func (s *Server) handleSetProbeInterval(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "missing session id", http.StatusBadRequest)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	intervalSec, err := strconv.Atoi(r.FormValue("interval"))
+	if err != nil {
+		http.Error(w, "invalid interval", http.StatusBadRequest)
+		return
+	}
+
+	if _, ok := s.sm.GetSession(id); !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	if err := s.sm.SetSessionProbeInterval(id, time.Duration(intervalSec)*time.Second); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Return the updated session row.
+	cur, ok := s.sm.GetSession(id)
+	if !ok {
+		// Disappeared between calls — just return the full list.
+		s.handleSessionsList(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.tmpl.ExecuteTemplate(w, "session_row.html", *cur); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 // handleInstances queries EC2 for running instances and returns the instance
@@ -247,12 +332,20 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// Render the session list partial.
-			var sessionsBuf bytes.Buffer
-			sessions := s.sm.ListSessions()
-			if err := s.tmpl.ExecuteTemplate(&sessionsBuf, "session_list.html", sessions); err == nil {
-				fmt.Fprintf(w, "event: sessions\ndata: %s\n\n",
-					strings.ReplaceAll(sessionsBuf.String(), "\n", "\ndata: "))
+			active, stopped := splitSessions(s.sm.ListSessions())
+
+			// Render the active session list partial.
+			var activeBuf bytes.Buffer
+			if err := s.tmpl.ExecuteTemplate(&activeBuf, "session_list.html", active); err == nil {
+				fmt.Fprintf(w, "event: active-sessions\ndata: %s\n\n",
+					strings.ReplaceAll(activeBuf.String(), "\n", "\ndata: "))
+			}
+
+			// Render the stopped session list partial.
+			var stoppedBuf bytes.Buffer
+			if err := s.tmpl.ExecuteTemplate(&stoppedBuf, "session_list.html", stopped); err == nil {
+				fmt.Fprintf(w, "event: stopped-sessions\ndata: %s\n\n",
+					strings.ReplaceAll(stoppedBuf.String(), "\n", "\ndata: "))
 			}
 
 			// Render the stats partial.
@@ -270,14 +363,16 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 // buildDashboardData assembles the template data for the dashboard.
 func (s *Server) buildDashboardData() DashboardData {
+	active, stopped := splitSessions(s.sm.ListSessions())
 	return DashboardData{
-		Sessions:     s.sm.ListSessions(),
-		SessionCount: s.sm.SessionCount(),
-		Uptime:       uptimeSince(s.startedAt),
-		Port:         s.cfg.DashboardPort,
-		SparkSVG:     template.HTML(renderSparkSVG(s.sm.SparkData())),
-		Presets:      s.cfg.Presets,
-		LastUpdate:   time.Now().Format("15:04:05"),
+		ActiveSessions:  active,
+		StoppedSessions: stopped,
+		SessionCount:    len(active),
+		Uptime:          uptimeSince(s.startedAt),
+		Port:            s.cfg.DashboardPort,
+		SparkSVG:        template.HTML(renderSparkSVG(s.sm.SparkData())),
+		Presets:         s.cfg.Presets,
+		LastUpdate:      time.Now().Format("15:04:05"),
 	}
 }
 
@@ -340,6 +435,8 @@ func sessionStateClass(state session.SessionState) string {
 		return "bg-yellow-500"
 	case session.StateStalled:
 		return "bg-amber-500"
+	case session.StateReconnecting:
+		return "bg-sky-500"
 	case session.StateErrored:
 		return "bg-red-500"
 	case session.StateStopped:
@@ -360,6 +457,8 @@ func sessionStateName(state session.SessionState) string {
 		return "Stopping"
 	case session.StateStalled:
 		return "Stalled"
+	case session.StateReconnecting:
+		return "Reconnecting"
 	case session.StateErrored:
 		return "Errored"
 	case session.StateStopped:
@@ -367,6 +466,17 @@ func sessionStateName(state session.SessionState) string {
 	default:
 		return "Unknown"
 	}
+}
+
+// isActiveState returns true for states that represent a live or
+// recovering session (i.e. not Stopped/Errored).
+func isActiveState(state session.SessionState) bool {
+	switch state {
+	case session.StateStarting, session.StateRunning, session.StateStopping,
+		session.StateStalled, session.StateReconnecting:
+		return true
+	}
+	return false
 }
 
 // sessionTypeName returns a human-readable label for a session type.

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -42,6 +42,18 @@ func NewServer(sm *session.SessionManager, cfg *config.Config, startedAt time.Ti
 		"portDisplay":         portDisplay,
 		"sessionProbeDisplay": sessionProbeDisplay,
 		"uptimeSince":         uptimeSince,
+		"isActiveState":       isActiveState,
+		"effectiveProbeSecs": func(s session.Session) int {
+			d := s.ProbeInterval
+			if d <= 0 {
+				d = sm.DefaultProbeInterval()
+			}
+			if d <= 0 {
+				return 30
+			}
+			return int(d / time.Second)
+		},
+		"reconnectMaxAttempts": func() int { return cfg.ReconnectMaxAttempts },
 	}
 
 	tmpl := template.Must(
@@ -91,6 +103,8 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("GET /api/sessions", s.handleSessionsList)
 	s.mux.HandleFunc("POST /api/sessions", s.handleStartSession)
 	s.mux.HandleFunc("DELETE /api/sessions/{id}", s.handleStopSession)
+	s.mux.HandleFunc("POST /api/sessions/{id}/reconnect", s.handleReconnectSession)
+	s.mux.HandleFunc("POST /api/sessions/{id}/probe-interval", s.handleSetProbeInterval)
 	s.mux.HandleFunc("GET /api/instances", s.handleInstances)
 	s.mux.HandleFunc("GET /api/profiles", s.handleProfiles)
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os/exec"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +23,35 @@ import (
 	"github.com/bovinemagnet/gossm/internal/config"
 	"github.com/bovinemagnet/gossm/internal/session"
 )
+
+// testServerWithSleep builds a Server backed by a session manager that
+// spawns harmless `sleep 3600` subprocesses, so reconnect logic can be
+// exercised without invoking the AWS CLI. Returns the server and the
+// underlying manager so tests can drive sessions directly.
+func testServerWithSleep(t *testing.T) (*Server, *session.SessionManager, *atomic.Int32) {
+	t.Helper()
+	var calls atomic.Int32
+	builder := func(ctx context.Context, opts session.SessionOpts) *exec.Cmd {
+		calls.Add(1)
+		return exec.CommandContext(ctx, "sleep", "3600")
+	}
+	sm := session.New(builder, nil)
+	sm.SetReconnectPolicy(1, 5, 5*time.Millisecond, 20*time.Millisecond)
+	sm.SetSleeper(func(time.Duration) {})
+	sm.SetProbe(nil, 0, 0)
+	cfg := &config.Config{
+		DashboardPort: 8877,
+		LogLevel:      "warn",
+		PIDDir:        t.TempDir(),
+		ProbeInterval: 30 * time.Second,
+	}
+	s := NewServer(sm, cfg, time.Now(), nil)
+	t.Cleanup(func() {
+		sm.Close()
+		s.Stop()
+	})
+	return s, sm, &calls
+}
 
 func testServer(t *testing.T) *Server {
 	t.Helper()
@@ -628,6 +660,171 @@ func TestStatsRendersHeartbeat(t *testing.T) {
 	// The pulse element should be rendered with the heartbeat-pulse class.
 	if !strings.Contains(body, "heartbeat-pulse") {
 		t.Errorf("stats response missing pulse element with class 'heartbeat-pulse': %s", body)
+	}
+}
+
+// --- Reconnect & probe-interval handler tests ---
+
+func TestReconnectHandler_TriggersBuilder(t *testing.T) {
+	srv, sm, calls := testServerWithSleep(t)
+
+	id, err := sm.StartSession(session.SessionOpts{
+		InstanceID: "i-recon",
+		Type:       session.TypePortForward,
+		LocalPort:  19990,
+		RemotePort: 19990,
+		RemoteHost: "host",
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	// Initial spawn registered.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && calls.Load() < 1 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if calls.Load() < 1 {
+		t.Fatalf("initial builder call never occurred")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/reconnect", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && calls.Load() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if calls.Load() < 2 {
+		t.Errorf("builder calls = %d, want >= 2 after manual reconnect", calls.Load())
+	}
+}
+
+func TestReconnectHandler_RejectsExternal(t *testing.T) {
+	srv, sm, _ := testServerWithSleep(t)
+
+	id := sm.RegisterExternal(session.SessionOpts{
+		InstanceID: "i-ext",
+		Type:       session.TypePortForward,
+		LocalPort:  19991,
+	}, 99999)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/reconnect", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (external session is not reconnectable)", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestReconnectHandler_MissingSession(t *testing.T) {
+	srv, _, _ := testServerWithSleep(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/no-such-id/reconnect", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestProbeIntervalHandler_UpdatesSession(t *testing.T) {
+	srv, sm, _ := testServerWithSleep(t)
+
+	id, err := sm.StartSession(session.SessionOpts{
+		InstanceID: "i-int",
+		Type:       session.TypePortForward,
+		LocalPort:  19992,
+		RemotePort: 19992,
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	form := url.Values{}
+	form.Set("interval", "15")
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/probe-interval", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	if got := sm.EffectiveProbeInterval(id); got != 15*time.Second {
+		t.Errorf("EffectiveProbeInterval = %v, want 15s", got)
+	}
+}
+
+func TestProbeIntervalHandler_RejectsOutOfRange(t *testing.T) {
+	srv, sm, _ := testServerWithSleep(t)
+
+	id, err := sm.StartSession(session.SessionOpts{
+		InstanceID: "i-bad",
+		Type:       session.TypePortForward,
+		LocalPort:  19993,
+		RemotePort: 19993,
+	})
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	cases := []string{"0", "-5", "601"}
+	for _, v := range cases {
+		t.Run(v, func(t *testing.T) {
+			form := url.Values{}
+			form.Set("interval", v)
+			req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/probe-interval", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("interval=%s status = %d, want %d", v, w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestSessionRowRendersReconnectingState(t *testing.T) {
+	sm := session.New(nil, nil)
+	defer sm.Close()
+	srv := NewServer(sm, &config.Config{
+		ProbeInterval:        30 * time.Second,
+		ReconnectMaxAttempts: 5,
+	}, time.Now(), nil)
+	defer srv.Stop()
+
+	s := session.Session{
+		ID:                "rec-1",
+		InstanceID:        "i-zzz",
+		InstanceName:      "tunnel",
+		Type:              session.TypePortForward,
+		State:             session.StateReconnecting,
+		LocalPort:         5000,
+		RemotePort:        5000,
+		RemoteHost:        "h",
+		StartedAt:         time.Now().Add(-time.Minute),
+		Reconnectable:     true,
+		ReconnectAttempts: 2,
+	}
+
+	var buf bytes.Buffer
+	if err := srv.tmpl.ExecuteTemplate(&buf, "session_row.html", s); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Reconnecting") {
+		t.Errorf("rendered row missing 'Reconnecting' label: %s", out)
+	}
+	if !strings.Contains(out, "2/5") {
+		t.Errorf("rendered row missing attempt indicator '2/5': %s", out)
 	}
 }
 

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -5,10 +5,10 @@
         {{template "stats.html" .}}
     </div>
 
-    <!-- Session table -->
+    <!-- Active sessions table -->
     <div id="sessions-section" class="bg-slate-800 rounded-lg border border-slate-700 shadow-lg mt-6">
         <div class="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
-            <h2 class="text-lg font-semibold text-slate-200">Sessions</h2>
+            <h2 class="text-lg font-semibold text-slate-200">Active Sessions</h2>
             <button
                 hx-get="/api/sessions"
                 hx-target="#session-table-body"
@@ -31,9 +31,42 @@
                         <th class="px-6 py-3 font-medium">Actions</th>
                     </tr>
                 </thead>
-                <tbody id="session-table-body" sse-swap="sessions" hx-swap="innerHTML"
+                <tbody id="session-table-body" sse-swap="active-sessions" hx-swap="innerHTML"
                        hx-get="/api/sessions" hx-trigger="every 5s">
-                    {{template "session_list.html" .Sessions}}
+                    {{template "session_list.html" .ActiveSessions}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Stopped sessions table -->
+    <div id="stopped-sessions-section" class="bg-slate-800 rounded-lg border border-slate-700 shadow-lg mt-6">
+        <div class="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
+            <h2 class="text-lg font-semibold text-slate-200">Stopped Sessions</h2>
+            <button
+                hx-get="/api/sessions?stopped=1"
+                hx-target="#stopped-session-table-body"
+                hx-swap="innerHTML"
+                class="text-sm text-sky-400 hover:text-sky-300 transition-colors">
+                Refresh
+            </button>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="text-left text-slate-400 border-b border-slate-700">
+                        <th class="px-6 py-3 font-medium">Status</th>
+                        <th class="px-6 py-3 font-medium">Instance Name</th>
+                        <th class="px-6 py-3 font-medium">Instance ID</th>
+                        <th class="px-6 py-3 font-medium">Profile</th>
+                        <th class="px-6 py-3 font-medium">Type</th>
+                        <th class="px-6 py-3 font-medium">Ports</th>
+                        <th class="px-6 py-3 font-medium">Uptime</th>
+                        <th class="px-6 py-3 font-medium">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="stopped-session-table-body" sse-swap="stopped-sessions" hx-swap="innerHTML">
+                    {{template "session_list.html" .StoppedSessions}}
                 </tbody>
             </table>
         </div>

--- a/internal/web/templates/partials/session_list.html
+++ b/internal/web/templates/partials/session_list.html
@@ -1,1 +1,1 @@
-{{define "session_list.html"}}{{if .}}{{range .}}{{template "session_row.html" .}}{{end}}{{else}}<tr><td colspan="8" class="px-6 py-12 text-center text-slate-500">No active sessions. Start one below.</td></tr>{{end}}{{end}}
+{{define "session_list.html"}}{{if .}}{{range .}}{{template "session_row.html" .}}{{end}}{{else}}<tr><td colspan="8" class="px-6 py-8 text-center text-slate-500">No sessions.</td></tr>{{end}}{{end}}

--- a/internal/web/templates/partials/session_row.html
+++ b/internal/web/templates/partials/session_row.html
@@ -3,10 +3,25 @@
     <td class="px-6 py-3">
         <div class="flex items-center space-x-2">
             <span class="status-dot {{sessionStateClass .State}}"></span>
-            <span class="text-xs text-slate-400">{{sessionStateName .State}}</span>
+            <span class="text-xs text-slate-400">
+                {{sessionStateName .State}}{{if and (eq (sessionStateName .State) "Reconnecting") .Reconnectable}} ({{.ReconnectAttempts}}/{{reconnectMaxAttempts}}){{end}}
+            </span>
         </div>
         {{if eq (sessionTypeName .Type) "Port Forward"}}
         <div class="text-[10px] text-slate-500 mt-1">probe: {{sessionProbeDisplay .}}</div>
+        <form hx-post="/api/sessions/{{.ID}}/probe-interval"
+              hx-target="closest tr"
+              hx-swap="outerHTML"
+              hx-trigger="change from:find input"
+              class="mt-1">
+            <label class="text-[10px] text-slate-500">
+                interval:
+                <input type="number" name="interval" min="1" max="600"
+                       value="{{effectiveProbeSecs .}}"
+                       class="w-14 bg-slate-800 border border-slate-700 rounded px-1 py-0.5 text-[10px] text-slate-300">
+                s
+            </label>
+        </form>
         {{end}}
     </td>
     <td class="px-6 py-3 font-medium text-slate-200">{{.InstanceName}}</td>
@@ -21,18 +36,28 @@
     <td class="px-6 py-3 font-mono text-xs text-slate-400">{{portDisplay .}}</td>
     <td class="px-6 py-3 text-slate-400 text-xs">{{uptimeSince .StartedAt}}</td>
     <td class="px-6 py-3">
-        {{$state := sessionStateName .State}}
-        {{if or (eq $state "Running") (eq $state "Starting") (eq $state "Stalled")}}
-        <button hx-delete="/api/sessions/{{.ID}}"
-                hx-target="#session-table-body"
-                hx-swap="innerHTML"
-                hx-confirm="Stop this session?"
-                class="text-red-400 hover:text-red-300 text-xs font-medium transition-colors">
-            Stop
-        </button>
-        {{else}}
-        <span class="text-slate-600 text-xs">-</span>
-        {{end}}
+        <div class="flex items-center space-x-3">
+            {{if isActiveState .State}}
+            <button hx-delete="/api/sessions/{{.ID}}"
+                    hx-target="#session-table-body"
+                    hx-swap="innerHTML"
+                    hx-confirm="Stop this session?"
+                    class="text-red-400 hover:text-red-300 text-xs font-medium transition-colors">
+                Stop
+            </button>
+            {{end}}
+            {{if and .Reconnectable (or (eq (sessionStateName .State) "Stalled") (eq (sessionStateName .State) "Errored") (eq (sessionStateName .State) "Stopped") (eq (sessionStateName .State) "Reconnecting"))}}
+            <button hx-post="/api/sessions/{{.ID}}/reconnect"
+                    hx-target="#session-table-body"
+                    hx-swap="innerHTML"
+                    class="text-sky-400 hover:text-sky-300 text-xs font-medium transition-colors">
+                Reconnect
+            </button>
+            {{end}}
+            {{if and (not (isActiveState .State)) (not .Reconnectable)}}
+            <span class="text-slate-600 text-xs">-</span>
+            {{end}}
+        </div>
     </td>
 </tr>
 {{end}}

--- a/src/docs/modules/ROOT/pages/configuration.adoc
+++ b/src/docs/modules/ROOT/pages/configuration.adoc
@@ -51,6 +51,33 @@ Lower levels include all messages from higher levels (i.e. `debug` includes `inf
 |Directory where gossm writes the PID file (`gossm.pid`) and Unix domain socket (`gossm.sock`).
 The directory is created automatically if it does not exist.
 |`~/.gossm`
+
+|`GOSSM_PROBE_INTERVAL`
+|How often the daemon probes each active port-forward tunnel by opening a short TCP connection to
+the local port. Accepts Go duration syntax (e.g. `30s`, `1m`).
+|`30s`
+
+|`GOSSM_PROBE_TIMEOUT`
+|Timeout for each TCP probe dial.
+|`2s`
+
+|`GOSSM_RECONNECT_FAILURE_THRESHOLD`
+|Number of consecutive failed probes before the daemon triggers an automatic reconnect.
+|`1`
+
+|`GOSSM_RECONNECT_MAX_ATTEMPTS`
+|Maximum number of respawn attempts before giving up and moving the session to the *Errored* state.
+|`5`
+
+|`GOSSM_RECONNECT_BACKOFF_INITIAL`
+|Initial backoff duration between reconnect attempts. The backoff doubles after each attempt up to
+the cap set by `GOSSM_RECONNECT_BACKOFF_MAX`. Accepts Go duration syntax.
+|`5s`
+
+|`GOSSM_RECONNECT_BACKOFF_MAX`
+|Maximum backoff duration between reconnect attempts. The doubling backoff is capped at this value.
+Accepts Go duration syntax.
+|`60s`
 |===
 
 === Example ~/.gossm/config
@@ -60,6 +87,14 @@ The directory is created automatically if it does not exist.
 GOSSM_PORT=8877
 GOSSM_LOG_LEVEL=warn
 GOSSM_PID_DIR=/home/myuser/.gossm
+
+# Optional: tune port-forward tunnel probing and auto-reconnect behaviour
+# GOSSM_PROBE_INTERVAL=30s
+# GOSSM_PROBE_TIMEOUT=2s
+# GOSSM_RECONNECT_FAILURE_THRESHOLD=1
+# GOSSM_RECONNECT_MAX_ATTEMPTS=5
+# GOSSM_RECONNECT_BACKOFF_INITIAL=5s
+# GOSSM_RECONNECT_BACKOFF_MAX=60s
 ----
 
 === Example .env (project-level)

--- a/src/docs/modules/ROOT/pages/port-forwarding.adoc
+++ b/src/docs/modules/ROOT/pages/port-forwarding.adoc
@@ -155,13 +155,51 @@ can be stopped from the browser.
 
 == Tunnel liveness
 
-Port-forward sessions are probed every 30 seconds by the daemon. The probe opens a short TCP connection to `127.0.0.1:<local-port>` with a 2-second timeout and records the outcome on the session.
+Port-forward sessions are probed periodically by the daemon. The probe opens a short TCP connection to `127.0.0.1:<local-port>` with a configurable timeout and records the outcome on the session.
 
-The dashboard surfaces the result under the status cell as `probe: ok 12s ago` or `probe: fail 4s ago`. A run of failures flips the session into the *Stalled* state (amber dot) so you can tell at a glance that the tunnel is no longer carrying traffic, even when the local `session-manager-plugin` process is still running.
+The dashboard surfaces the result under the status cell as `probe: ok 12s ago` or `probe: fail 4s ago`. A run of consecutive failures (controlled by `GOSSM_RECONNECT_FAILURE_THRESHOLD`) first flips the session into the *Stalled* state (amber indicator) so you can tell at a glance that the tunnel is no longer carrying traffic, even when the local `session-manager-plugin` process is still running.
 
 The probe doubles as keepalive traffic: most networks will not idle-out a tunnel that sees a TCP connection every 30 seconds, so this also reduces the rate at which AWS Session Manager closes idle sessions.
 
-Stalled sessions can be stopped from the dashboard like any other session. Probing is not performed for shell sessions; their status cell shows `probe: —`.
+Probing is not performed for shell sessions; their status cell shows `probe: —`.
+
+=== Automatic reconnect
+
+When a daemon-managed port-forward session stalls or its `aws ssm start-session` subprocess exits unexpectedly, the daemon automatically respawns it. The reconnected session retains the same session ID, local port, remote port, remote host, profile, and target — only the underlying subprocess is replaced.
+
+The session moves through the *Reconnecting* state while respawn is in progress. The dashboard shows this as `Reconnecting (n/N)` where `n` is the current attempt number and `N` is the configured maximum.
+
+The backoff sequence with default settings is: 5 s → 10 s → 20 s → 40 s → 60 s.
+
+If all reconnect attempts are exhausted the session transitions to *Errored* and no further attempts are made. Errored sessions appear in the *Stopped Sessions* table on the dashboard (see <<dashboard-tables>>).
+
+=== Manual reconnect button
+
+Each reconnectable session in the dashboard has a *Reconnect* button that immediately triggers a fresh respawn, resetting the attempt counter. You can also adjust the per-session probe interval using the probe-interval input field (1–600 seconds); this overrides the daemon-wide `GOSSM_PROBE_INTERVAL` for that session only.
+
+NOTE: CLI-launched sessions that were registered with a running daemon (external sessions) are *not* reconnectable. The daemon does not own their subprocess and cannot safely respawn them. The Reconnect button does not appear for these sessions. Shell sessions are also not reconnectable as they are interactive.
+
+[[dashboard-tables]]
+=== Dashboard session tables
+
+The dashboard splits sessions into two tables:
+
+Active Sessions::
+Sessions in the *Starting*, *Running*, *Stopping*, *Stalled*, or *Reconnecting* state.
+These are sessions the daemon is actively managing or monitoring.
+
+Stopped Sessions::
+Sessions in the *Stopped* or *Errored* state.
+A session reaches *Errored* when all automatic reconnect attempts are exhausted.
+A session reaches *Stopped* when it is terminated by the user or shuts down cleanly.
+
+=== Probe and reconnect configuration
+
+All probe and reconnect settings are controlled by environment variables. See the
+xref:configuration.adoc[Configuration] page for the full reference, including
+`GOSSM_PROBE_INTERVAL`, `GOSSM_PROBE_TIMEOUT`, `GOSSM_RECONNECT_FAILURE_THRESHOLD`,
+`GOSSM_RECONNECT_MAX_ATTEMPTS`, `GOSSM_RECONNECT_BACKOFF_INITIAL`, and
+`GOSSM_RECONNECT_BACKOFF_MAX`.
 
 == Flags Reference
 


### PR DESCRIPTION
## Summary

- Daemon-managed port-forward sessions now respawn automatically when the TCP probe fails past threshold or the `aws ssm start-session` subprocess exits unexpectedly. Same session ID, same opts.
- Adds manual **Reconnect** button + per-session probe-interval input on the dashboard, and a new `Reconnecting (n/N)` state.
- Splits the session list into **Active** and **Stopped** tables (previously stopped/errored rows mingled with running ones).
- Six new `GOSSM_*` env keys cover probe and reconnect tuning.

## Behaviour

- **Triggers**: probe failure ≥ threshold, unexpected subprocess exit, manual click. User-initiated stop never reconnects.
- **Retry**: max 5 attempts (configurable) with doubling backoff capped at 60s (5→10→20→40→60). On exhaustion → `Errored`. Manual click resets the counter.
- **Probe interval**: code default 30s → `.env`/config (`GOSSM_PROBE_INTERVAL`) → per-session inline number input (1–600s).
- **Out of scope by design**: CLI-launched external sessions (daemon doesn't own the subprocess) and shell sessions are not reconnectable.

## New env keys

| Key | Default |
|---|---|
| `GOSSM_PROBE_INTERVAL` | `30s` |
| `GOSSM_PROBE_TIMEOUT` | `2s` |
| `GOSSM_RECONNECT_FAILURE_THRESHOLD` | `1` |
| `GOSSM_RECONNECT_MAX_ATTEMPTS` | `5` |
| `GOSSM_RECONNECT_BACKOFF_INITIAL` | `5s` |
| `GOSSM_RECONNECT_BACKOFF_MAX` | `60s` |

## Test plan

- [x] `go test -race ./...` (12 new tests + existing suite)
- [x] `go vet ./...`
- [x] Antora build clean
- [ ] Manual: start a real port-forward, edit interval input, watch state flow
- [ ] Manual: kill the SSM plugin process, observe `Stalled → Reconnecting (n/5) → Running`
- [ ] Manual: block egress, verify `Errored` after 5 attempts; click Reconnect to recover
- [ ] Manual: confirm Stopped table picks up user-stopped + errored sessions